### PR TITLE
Add Gemini CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Agents OSS Helper
 
-Generic commands for AI coding agents (Claude, Bob) to help contribute to open source projects. Commands auto-detect the current project via `git remote get-url origin` and load project-specific configuration from rule files.
+Generic commands for AI coding agents (Claude, Bob, Gemini) to help contribute to open source projects. Commands auto-detect the current project via `git remote get-url origin` and load project-specific configuration from rule files.
 
 ## Supported Projects
 
@@ -22,7 +22,7 @@ Generic commands for AI coding agents (Claude, Bob) to help contribute to open s
 
 ## Installation
 
-### Quick Install (Both Agents)
+### Quick Install (All Agents)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/orpiske/ai-agents-oss-helper/main/install.sh | bash
@@ -38,7 +38,8 @@ cd ai-agents-oss-helper
 # Install for specific agent
 ./install.sh claude    # Claude only
 ./install.sh bob       # Bob only
-./install.sh           # Both
+./install.sh gemini    # Gemini CLI only
+./install.sh           # All agents
 ```
 
 ## Available Commands
@@ -166,6 +167,12 @@ When a command runs, it:
 2. Matches against remote patterns to determine the project directory
 3. Reads project-specific configuration from `rules/<project>/`
 4. Adapts behavior accordingly (GitHub vs Jira, build commands, constraints, etc.)
+
+## Gemini CLI Notes
+
+Gemini CLI uses TOML command files instead of Markdown. The installer automatically converts `.md` commands to `.toml` format at install time, wrapping the prompt content and extracting the description.
+
+Since Gemini CLI has no auto-loading `rules/` directory, each generated TOML command includes a preamble instructing Gemini to read project rule files from `~/.gemini/rules/<project-directory>/`.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- Add Gemini CLI as a supported agent alongside Claude and Bob
- Auto-convert `.md` command files to Gemini's `.toml` format at install time, extracting descriptions and wrapping prompts
- Include a preamble in each TOML command instructing Gemini to read project rule files from `~/.gemini/rules/<project-directory>/`
- Update README with Gemini install option and CLI notes

## Test plan
- [ ] Run `./install.sh gemini` and verify `.toml` files appear in `~/.gemini/commands/`
- [ ] Spot-check a generated `.toml` for valid `description` and `prompt` fields
- [ ] Verify rules installed to `~/.gemini/rules/<project>/`
- [ ] Run `./install.sh` (all agents) and confirm no errors