### PR TITLE
Added oss-fix-ci-errors command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ cd ai-agents-oss-helper
 | `/oss-fix-sonarcloud <rule>` | Fix SonarCloud issues for a given rule |
 | `/oss-add-project <name> <description>` | Register a new project with the helper |
 | `/oss-update-knowledge <source>` | Update a project's rule files from a description or URL |
+| `/oss-fix-ci-errors [run-id]` | Download CI build reports, identify errors, and fix them |
 
 All commands auto-detect the project from the current directory's git remote.
 
@@ -188,7 +189,8 @@ ai-agents-oss-helper/
 │   ├── oss-analyze-issue.md
 │   ├── oss-fix-sonarcloud.md
 │   ├── oss-add-project.md
-│   └── oss-update-knowledge.md
+│   ├── oss-update-knowledge.md
+│   └── oss-fix-ci-errors.md
 └── rules/                            # Rule files (installed to ~/.{agent}/rules/)
     ├── wanaku/
     │   ├── project-info.md

--- a/commands/oss-fix-ci-errors.md
+++ b/commands/oss-fix-ci-errors.md
@@ -1,0 +1,187 @@
+# Fix CI Errors
+
+Download CI build reports, identify errors, and fix them properly.
+
+## Usage
+
+```
+/oss-fix-ci-errors [run-id]
+```
+
+**Arguments:**
+- `[run-id]` - GitHub Actions run ID (optional). If omitted, auto-detects the latest failed run on the default branch.
+
+## Instructions
+
+### 1. Detect Project
+
+Determine the current project by running:
+
+```bash
+git remote get-url origin
+```
+
+Match the output against the remote patterns to determine the project directory:
+- `wanaku-ai/wanaku` -> `wanaku`
+- `wanaku-ai/wanaku-capabilities-java-sdk` -> `wanaku-capabilities-java-sdk`
+- `wanaku-ai/camel-integration-capability` -> `camel-integration-capability`
+- `apache/camel` -> `camel-core`
+- `apache/camel-quarkus` -> `camel-quarkus`
+- `apache/camel-spring-boot` -> `camel-spring-boot`
+- `apache/camel-kafka-connector` -> `camel-kafka-connector`
+- `apache/camel-k` -> `camel-k`
+- `hawtio/hawtio` -> `hawtio`
+- `KaotoIO/kaoto` -> `kaoto`
+- `KaotoIO/forage` -> `forage`
+- `orpiske/ai-agents-oss-helper` -> `ai-agents-oss-helper`
+
+If no match is found, fall back to the `generic-github` rules directory. Extract the GitHub org/repo from the remote URL (e.g., `https://github.com/org/repo.git` or `git@github.com:org/repo.git` -> `org/repo`) and use it as the project's GitHub repository for all operations.
+
+Once matched, read the project's rule files from the corresponding subdirectory:
+- `<project>/project-info.md` - Repository metadata, issue tracker, related repos
+- `<project>/project-standards.md` - Build tools, commands, code style
+- `<project>/project-guidelines.md` - Branching, commits, PR policies
+
+### 2. Parse Input
+
+- If a run ID is provided, use it directly.
+- If omitted, find the latest failed runs:
+
+```bash
+gh run list --repo <REPO> --status failure --branch main --limit 5 --json databaseId,name,conclusion,headBranch,event,createdAt
+```
+
+Present the failed runs to the user and ask which to investigate, or use the most recent one.
+
+### 3. Download CI Logs
+
+Fetch the failed job logs:
+
+```bash
+gh run view <RUN_ID> --repo <REPO> --log-failed
+```
+
+If the log output is too large, first identify the failed jobs:
+
+```bash
+gh run view <RUN_ID> --repo <REPO> --json jobs
+```
+
+Then download logs for specific failed jobs individually.
+
+### 4. Analyze Errors
+
+Parse the logs to identify error categories:
+
+- **Compilation errors** - Missing imports, type mismatches, syntax errors
+- **Test failures** - Assertion failures, unexpected exceptions, timeouts
+- **Lint/style violations** - Checkstyle, spotless, formatting errors
+- **Dependency resolution failures** - Missing or conflicting dependencies
+- **Configuration errors** - Invalid build configuration, missing properties
+
+Group errors by type and affected files.
+
+### 5. Triage Errors
+
+Classify each error into one of two categories:
+
+**A. Directly fixable** - Clear root cause, straightforward fix:
+- Compilation errors with obvious cause
+- Simple test fixes (e.g., updated API, renamed method)
+- Dependency version issues
+- Style/formatting violations
+
+**B. Needs investigation** - Root cause unclear or fix is non-trivial:
+- Intermittent test failures
+- Complex logic bugs
+- Design-level issues
+- Problems requiring upstream changes
+
+For category B errors: create a GitHub issue (using the same approach as `/oss-create-issue`) describing the error, its context, and the CI run link.
+
+Present the triage summary to the user for confirmation before proceeding with any fixes.
+
+### 6. Implement Fixes
+
+For category A errors:
+
+1. Fix the root cause of each error
+2. Follow the project's `project-standards.md` for code style and build constraints
+3. For category B errors that can be partially addressed without shallow workarounds, fix what is genuinely possible
+
+### 7. Constraints
+
+You MUST:
+- Fix root causes, not symptoms
+- Create tickets for problems too large to fix inline
+- Reference created tickets in the PR description
+- Verify fixes locally with build/test commands from the project's `project-standards.md`
+- Present the full analysis to the user before making any changes
+
+You MUST NOT:
+- Disable, skip, or delete failing tests (`@Ignore`, `@Disabled`, `skipTests`, `-DskipTests`, etc.)
+- Weaken assertions (e.g., removing asserts, loosening expected values, widening tolerances)
+- Suppress warnings or errors without addressing the root cause
+- Add `@SuppressWarnings` without genuine justification
+- Catch and swallow exceptions to hide failures
+- Reduce test coverage
+- Apply any workaround whose sole purpose is making CI green
+- Mark tests as flaky without proper investigation
+- Comment out failing code
+
+### 8. Workflow
+
+Read branch naming and commit format from the project's `project-guidelines.md`.
+
+1. **Branch**: Create from main
+   ```bash
+   git checkout main && git pull && git checkout -b ci-fix/<short-slug>
+   ```
+   Use the CI-fix branch pattern from the project's `project-guidelines.md`.
+
+2. **Implement**: Apply the fixes for category A errors
+
+3. **Format & Build**: Run the build commands from the project's `project-standards.md`
+   - For projects with module-specific builds: run in the affected module directory
+   - For other projects: run from root
+
+4. **Commit**: Use the CI-fix commit format from the project's `project-guidelines.md`
+   ```bash
+   git add <changed-files>
+   git commit -m "ci: <brief description>"
+   ```
+
+5. **Push**: Push branch to origin
+   ```bash
+   git push -u origin ci-fix/<short-slug>
+   ```
+
+6. **PR**: Create a pull request with a description listing:
+   - Link to the failed CI run
+   - Errors found and fixes applied
+   - Tickets created for deferred issues (if any)
+
+   ```bash
+   gh pr create --title "ci: <brief description>" --body "$(cat <<'EOF'
+   ## CI Fix
+
+   **Failed run:** <link to CI run>
+
+   ### Errors Fixed
+   - <error 1>: <fix applied>
+   - <error 2>: <fix applied>
+
+   ### Deferred Issues
+   - <ticket link>: <brief description> (if any)
+   EOF
+   )"
+   ```
+
+### 9. Acceptance Criteria
+
+- Local build and tests pass (using commands from the project's `project-standards.md`)
+- Fixes address genuine root causes
+- No test suppression, coverage reduction, or assertion weakening
+- PR links to the failed CI run
+- Tickets created for any deferred problems
+- User approved the triage before fixes were applied

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,7 @@ COMMAND_FILES=(
     "commands/oss-fix-sonarcloud.md"
     "commands/oss-add-project.md"
     "commands/oss-update-knowledge.md"
+    "commands/oss-fix-ci-errors.md"
 )
 
 # Rule files to install (relative paths from repo root)

--- a/rules/ai-agents-oss-helper/project-guidelines.md
+++ b/rules/ai-agents-oss-helper/project-guidelines.md
@@ -7,6 +7,8 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **SonarCloud branch:** _(not configured)_
 - **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (ci-fix):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/camel-core/project-guidelines.md
+++ b/rules/camel-core/project-guidelines.md
@@ -7,6 +7,8 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **SonarCloud branch:** `ci-camel-4-sonarcloud-<rule>` (customizable via `branch=<name>` option)
 - **Commit format (fix-issue):** `<ISSUE_ID>: <brief description of fix>`
 - **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (ci-fix):** `ci: <brief description>`
 - **Commit format (sonarcloud):** `(chores): fix SonarCloud <rule> in <component>`
 - **PR creation:** always
 - **Find-task source:** Jira

--- a/rules/camel-integration-capability/project-guidelines.md
+++ b/rules/camel-integration-capability/project-guidelines.md
@@ -7,6 +7,8 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **SonarCloud branch:** _(not configured)_
 - **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (ci-fix):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/camel-k/project-guidelines.md
+++ b/rules/camel-k/project-guidelines.md
@@ -7,6 +7,8 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **SonarCloud branch:** _(not configured)_
 - **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (ci-fix):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/camel-kafka-connector/project-guidelines.md
+++ b/rules/camel-kafka-connector/project-guidelines.md
@@ -7,6 +7,8 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **SonarCloud branch:** _(not configured)_
 - **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (ci-fix):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/camel-quarkus/project-guidelines.md
+++ b/rules/camel-quarkus/project-guidelines.md
@@ -7,6 +7,8 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **SonarCloud branch:** _(not configured)_
 - **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (ci-fix):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/camel-spring-boot/project-guidelines.md
+++ b/rules/camel-spring-boot/project-guidelines.md
@@ -7,6 +7,8 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **SonarCloud branch:** _(not configured)_
 - **Commit format (fix-issue):** `<ISSUE_ID>: <brief description of fix>`
 - **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (ci-fix):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** Jira
 - **Find-task beginner JQL:** `project = CAMEL AND status = Open AND labels = good-first-issue` (maxResults=10)

--- a/rules/forage/project-guidelines.md
+++ b/rules/forage/project-guidelines.md
@@ -7,6 +7,8 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **SonarCloud branch:** _(not configured)_
 - **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (ci-fix):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/generic-github/project-guidelines.md
+++ b/rules/generic-github/project-guidelines.md
@@ -7,6 +7,8 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **SonarCloud branch:** _(not configured)_
 - **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (ci-fix):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/hawtio/project-guidelines.md
+++ b/rules/hawtio/project-guidelines.md
@@ -7,6 +7,8 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **SonarCloud branch:** _(not configured)_
 - **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (ci-fix):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/kaoto/project-guidelines.md
+++ b/rules/kaoto/project-guidelines.md
@@ -7,6 +7,8 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **SonarCloud branch:** _(not configured)_
 - **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (ci-fix):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/wanaku-capabilities-java-sdk/project-guidelines.md
+++ b/rules/wanaku-capabilities-java-sdk/project-guidelines.md
@@ -7,6 +7,8 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **SonarCloud branch:** _(not configured)_
 - **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (ci-fix):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/wanaku/project-guidelines.md
+++ b/rules/wanaku/project-guidelines.md
@@ -7,6 +7,8 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **SonarCloud branch:** _(not configured)_
 - **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (ci-fix):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`


### PR DESCRIPTION
## Summary

- Added new `/oss-fix-ci-errors` command that downloads CI build reports, identifies errors, triages them, and fixes root causes
- Added `CI-fix branch` and `Commit format (ci-fix)` fields to all 13 project-guidelines files
- Updated `install.sh` and `README.md` to include the new command

The command enforces strict constraints against test suppression, assertion weakening, or any workarounds whose sole purpose is making CI green. Issues too large to fix inline are deferred to new tickets.