### PR TITLE
Add test with coverage command for Wanaku projects

### DIFF
--- a/rules/camel-integration-capability/project-standards.md
+++ b/rules/camel-integration-capability/project-standards.md
@@ -5,6 +5,7 @@ This rule file contains build tools, commands, and code style constraints for th
 - **Build tool:** Maven
 - **Build command:** `mvn verify`
 - **Test command:** `mvn verify`
+- **Test with coverage command:** `mvn verify -Pcoverage`
 - **Format command:** `mvn verify` (auto-formats during build)
 - **Module-specific build:** no (run from root)
 - **Parallelized Maven:** yes

--- a/rules/wanaku-capabilities-java-sdk/project-standards.md
+++ b/rules/wanaku-capabilities-java-sdk/project-standards.md
@@ -5,6 +5,7 @@ This rule file contains build tools, commands, and code style constraints for th
 - **Build tool:** Maven
 - **Build command:** `mvn verify`
 - **Test command:** `mvn verify`
+- **Test with coverage command:** `mvn verify -Pcoverage`
 - **Format command:** `mvn verify` (auto-formats during build)
 - **Module-specific build:** no (run from root)
 - **Parallelized Maven:** yes

--- a/rules/wanaku/project-standards.md
+++ b/rules/wanaku/project-standards.md
@@ -5,6 +5,7 @@ This rule file contains build tools, commands, and code style constraints for th
 - **Build tool:** Maven
 - **Build command:** `mvn verify`
 - **Test command:** `mvn verify`
+- **Test with coverage command:** `mvn verify -Pcoverage`
 - **Format command:** `mvn verify` (auto-formats during build)
 - **Module-specific build:** no (run from root)
 - **Parallelized Maven:** yes


### PR DESCRIPTION
## Summary
- Added `mvn verify -Pcoverage` as the test with coverage command for the three Wanaku projects: wanaku, wanaku-capabilities-java-sdk, and camel-integration-capability.

## Test plan
- [ ] Verify the coverage profile works correctly when running tests on each Wanaku project