### PR TITLE
Add the ability to provide the oss-helper rules from the git project

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,17 @@ cd ai-agents-oss-helper
 
 ## Available Commands
 
-| Command | Description |
-|---------|-------------|
-| `/oss-fix-issue <issue>` | Fix an issue from the project's tracker (GitHub or Jira) |
-| `/oss-find-task` | Find an issue to contribute based on experience level |
-| `/oss-create-issue <title>` | Create a new issue in the project's GitHub repository |
-| `/oss-quick-fix <description>` | Apply a quick fix without a tracked issue (CI, docs, deps, etc.) |
-| `/oss-analyze-issue <issue>` | Analyze an issue to understand the problem and investigate the codebase |
-| `/oss-fix-sonarcloud <rule>` | Fix SonarCloud issues for a given rule |
-| `/oss-add-project <name> <description>` | Register a new project with the helper |
-| `/oss-update-knowledge <source>` | Update a project's rule files from a description or URL |
-| `/oss-fix-ci-errors [run-id]` | Download CI build reports, identify errors, and fix them |
+| Command                                   | Description                                                             |
+|-------------------------------------------|-------------------------------------------------------------------------|
+| `/oss-fix-issue <issue>`                  | Fix an issue from the project's tracker (GitHub or Jira)                |
+| `/oss-find-task`                          | Find an issue to contribute based on experience level                   |
+| `/oss-create-issue <title>`               | Create a new issue in the project's GitHub repository                   |
+| `/oss-quick-fix <description>`            | Apply a quick fix without a tracked issue (CI, docs, deps, etc.)        |
+| `/oss-analyze-issue <issue>`              | Analyze an issue to understand the problem and investigate the codebase |
+| `/oss-fix-sonarcloud <rule>`              | Fix SonarCloud issues for a given rule                                  |
+| `/oss-add-project <name> <description>`  | Add a new project with the helper                                       |
+| `/oss-update-knowledge <source>`          | Update a project's rule files from a description or URL                 |
+| `/oss-fix-ci-errors [run-id]`             | Download CI build reports, identify errors, and fix them                |
 
 All commands auto-detect the project from the current directory's git remote.
 
@@ -156,18 +156,22 @@ The command will:
 
 ## How It Works
 
-Commands are generic and project-agnostic. Project-specific configuration is stored in rule files:
-
-Each project has its own subdirectory under `rules/` with three files:
+Commands are generic and project-agnostic. Project-specific configuration is stored in rule files with three files per project:
 - **`project-info.md`** - Repository URLs, issue trackers, SonarCloud keys, related repos
 - **`project-standards.md`** - Build tools, commands, code style restrictions
 - **`project-guidelines.md`** - Branch naming, commit formats, PR policies, task labels
 
-When a command runs, it:
-1. Detects the current project via `git remote get-url origin`
-2. Matches against remote patterns to determine the project directory
-3. Reads project-specific configuration from `rules/<project>/`
-4. Adapts behavior accordingly (GitHub vs Jira, build commands, constraints, etc.)
+Every command starts by processing `.oss-init.md`, which loads project rules in this priority order:
+
+1. **Project-local rules** - `.oss-ai-helper-rules/` directory in the repository root (highest priority, can be committed to the repo)
+2. **Installed rules** - Matching `rules/<project>/` from the installed helper (remote pattern matching)
+3. **Auto-discovery** - If no rules exist anywhere, the agent auto-discovers the project's configuration (build tool, conventions, etc.) and generates rule files (in `.oss-ai-helper-rules/` for git repos, or in the central `rules/` directory otherwise)
+
+### Project-local rules (`.oss-ai-helper-rules/`)
+
+Projects can ship their own AI helper rules by including a `.oss-ai-helper-rules/` directory in the repository root with the three rule files. This allows project maintainers to control how AI agents interact with their project, and contributors get the right configuration automatically without installing project-specific rules.
+
+If no `.oss-ai-helper-rules/` directory exists and the project isn't in the installed rules, the agent will auto-discover the project's build tool, conventions, and metadata, then generate rule files. For git repositories, rules are created in `.oss-ai-helper-rules/` so they can be committed and shared with other contributors. For non-git directories, rules are created in the central `rules/` directory.
 
 ## Gemini CLI Notes
 
@@ -182,15 +186,16 @@ ai-agents-oss-helper/
 ├── install.sh                        # Installation script
 ├── README.md
 ├── commands/                         # Generic commands (installed to ~/.{agent}/commands/)
+│   ├── oss-add-project.md
 │   ├── oss-fix-issue.md
 │   ├── oss-find-task.md
 │   ├── oss-create-issue.md
 │   ├── oss-quick-fix.md
 │   ├── oss-analyze-issue.md
 │   ├── oss-fix-sonarcloud.md
-│   ├── oss-add-project.md
 │   ├── oss-update-knowledge.md
-│   └── oss-fix-ci-errors.md
+│   ├── oss-fix-ci-errors.md
+│   └── .oss-init.md                  # Shared preamble: project detection & rule loading
 └── rules/                            # Rule files (installed to ~/.{agent}/rules/)
     ├── wanaku/
     │   ├── project-info.md

--- a/commands/.oss-init.md
+++ b/commands/.oss-init.md
@@ -1,0 +1,223 @@
+# OSS Helper - Initialization
+
+This file is processed at the beginning of every OSS Helper command. It detects the current project and loads its configuration rules.
+If no project rules are found, rules will be generated based on the source code and a default template.
+Do NOT skip this step!
+
+## Instructions
+
+### 1. Detect Project
+
+Determine the current project by running:
+
+```bash
+git remote get-url origin
+```
+
+Extract the GitHub org/repo from the remote URL:
+- `https://github.com/org/repo.git` -> `org/repo`
+- `git@github.com:org/repo.git` -> `org/repo`
+
+Determine the git repository root:
+
+```bash
+git rev-parse --show-toplevel
+```
+
+### 2. Load Project Rules
+
+Check for project rules in the following order. Use the **first source found**:
+
+#### A. Project-local rules (`.oss-ai-helper-rules/`)
+
+Check if `.oss-ai-helper-rules/` exists in the repository root:
+
+```bash
+ls <repo-root>/.oss-ai-helper-rules/
+```
+
+If the directory exists, read the project's rule files directly from it:
+- `<repo-root>/.oss-ai-helper-rules/project-info.md` - Repository metadata, issue tracker, related repos
+- `<repo-root>/.oss-ai-helper-rules/project-standards.md` - Build tools, commands, code style
+- `<repo-root>/.oss-ai-helper-rules/project-guidelines.md` - Branching, commits, PR policies
+
+These project-local rules take precedence over installed rules. Proceed to **step 3** (Version Check).
+
+#### B. Installed rules (remote pattern matching)
+
+If no `.oss-ai-helper-rules/` directory exists, match the git remote URL against known remote patterns to determine the project rules directory:
+- `wanaku-ai/wanaku` -> `wanaku`
+- `wanaku-ai/wanaku-capabilities-java-sdk` -> `wanaku-capabilities-java-sdk`
+- `wanaku-ai/camel-integration-capability` -> `camel-integration-capability`
+- `apache/camel` -> `camel-core`
+- `apache/camel-quarkus` -> `camel-quarkus`
+- `apache/camel-spring-boot` -> `camel-spring-boot`
+- `apache/camel-kafka-connector` -> `camel-kafka-connector`
+- `apache/camel-k` -> `camel-k`
+- `hawtio/hawtio` -> `hawtio`
+- `KaotoIO/kaoto` -> `kaoto`
+- `KaotoIO/forage` -> `forage`
+- `orpiske/ai-agents-oss-helper` -> `ai-agents-oss-helper`
+
+If a match is found, read the project's rule files from the corresponding subdirectory:
+- `<project>/project-info.md` - Repository metadata, issue tracker, related repos
+- `<project>/project-standards.md` - Build tools, commands, code style
+- `<project>/project-guidelines.md` - Branching, commits, PR policies
+
+Proceed to **step 3** (Version Check).
+
+#### C. Auto-discover and generate rules
+
+If neither `.oss-ai-helper-rules/` nor installed rules exist for this project, auto-discover the project's configuration and generate rule files.
+
+**Step C.1: Detect project metadata**
+
+Using the org/repo extracted in step 1:
+- **GitHub repo:** use the org/repo directly
+- **Issue tracker:** default to GitHub
+- **Issue ID format:** numeric
+- **SonarCloud component key:** _(none)_ unless discoverable
+- **Create-issue supported:** default to yes
+
+**Step C.2: Detect build tool and commands**
+
+Check for build files in the repository root to determine the build tool:
+
+| File found | Build tool | Build command | Test command | Format command |
+|------------|-----------|---------------|-------------|----------------|
+| `pom.xml` | Maven | `mvn verify` | `mvn test` | `mvn process-sources -P format` |
+| `build.gradle` or `build.gradle.kts` | Gradle | `./gradlew build` | `./gradlew test` | `./gradlew spotlessApply` (if Spotless plugin detected) |
+| `package.json` | npm/yarn | `npm run build` | `npm test` | `npm run format` (if script exists) |
+| `Makefile` | Make | `make` | `make test` | _(none)_ |
+| `go.mod` | Go | `go build ./...` | `go test ./...` | `gofmt -w .` |
+| `Cargo.toml` | Cargo | `cargo build` | `cargo test` | `cargo fmt` |
+
+If multiple build files exist, prefer the primary one (e.g., `pom.xml` over `Makefile`). Read the actual build configuration to refine commands (e.g., check for specific Maven profiles, Gradle tasks, npm scripts).
+
+**Step C.3: Detect project guidelines**
+
+Look for contribution guidelines in the repository:
+
+```bash
+ls <repo-root>/CONTRIBUTING.md <repo-root>/.github/CONTRIBUTING.md <repo-root>/docs/CONTRIBUTING.md 2>/dev/null
+```
+
+If a CONTRIBUTING file is found, read it and extract:
+- Branch naming conventions
+- Commit message format
+- PR policies
+
+If no CONTRIBUTING file is found, use these defaults:
+- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Quick-fix branch:** `quick-fix/<short-slug>`
+- **CI-fix branch:** `ci-fix/<short-slug>`
+- **Commit format (fix-issue):** `#<ISSUE_NUMBER>: <brief description>`
+- **Commit format (quick-fix):** `[chore]: <brief description>`
+- **Commit format (ci-fix):** `[ci]: <brief description>`
+- **PR creation:** always
+- **Find-task source:** GitHub labels
+- **Find-task beginner label:** `good first issue`
+- **Find-task experienced label:** `help wanted`
+- **Scope-too-large redirect:** `/oss-create-issue`
+
+**Step C.4: Create rule files**
+
+The target directory depends on whether this is a git repository:
+
+- **Git repository:** Create rules in `<repo-root>/.oss-ai-helper-rules/`. These can be committed and shared with other contributors.
+- **Not a git repository:** Create rules in the central `rules/<project-name>/` directory (where `<project-name>` is derived from the org/repo or directory name). Then update `install.sh` to include the new rule file paths and update `.oss-init.md` to add the remote pattern mapping.
+
+Create the directory and three rule files using the discovered/default values.
+Use the existing rule file templates (from installed rules like `generic-github/`) as a format reference.
+
+1. `project-info.md`
+Create with:
+- H1 heading: `# Project Information`
+- Intro paragraph (same as other project-info files)
+- Remote pattern
+- GitHub repo
+- Issue tracker type (GitHub or Jira)
+- Issue tracker URL
+- Issue ID format (numeric or alphanumeric)
+- SonarCloud component key
+- Documentation URL
+- Related repositories
+- Create-issue supported (yes/no)
+- `## Version` section with the current git SHA of the project being configured
+
+2. `project-standards.md`
+Create with:
+- H1 heading: `# Project Standards`
+- Intro paragraph (same as other project-standards files)
+- Build tool
+- Build command
+- Test command
+- Test with coverage command
+- Format command
+- Module-specific build (yes/no)
+- Parallelized Maven (yes/no/n/a)
+- Code style restrictions
+- `## Version` section with the current git SHA of the project being configured
+
+3. `project-guidelines.md`
+Create with:
+- H1 heading: `# Project Guidelines`
+- Intro paragraph (same as other project-guidelines files)
+- Fix-issue branch naming pattern
+- Quick-fix branch naming pattern
+- SonarCloud branch naming pattern
+- Commit format (fix-issue)
+- Commit format (quick-fix)
+- CI-fix branch naming pattern
+- Commit format (ci-fix)
+- PR creation policy (always/on request)
+- Find-task source (GitHub labels or Jira JQL)
+- Find-task beginner label
+- Find-task intermediate label
+- Find-task experienced label
+- Scope-too-large redirect
+- `## Version` section with the current git SHA of the project being configured
+
+Use existing project files (e.g., `rules/wanaku/`) as a template for the exact format.
+
+After creating the files, inform the user:
+
+- **Git repository:** > Project rules auto-generated in `.oss-ai-helper-rules/`. Review and adjust these files as needed. You can commit them to share with other contributors.
+- **Not a git repository:** > Project rules auto-generated in `rules/<project-name>/`. Review and adjust these files as needed.
+
+Then read the newly created rule files to continue with the command. Skip step 3 (newly created rules are already up to date).
+
+### 3. Version Check
+
+After loading rule files (from step 2A or 2B), check if a newer version is available in the project's GitHub repository.
+
+#### 3.1 Extract local version
+
+Read the `## Version` section from the loaded `project-info.md` file. Extract the version string (a git SHA). If no `## Version` section exists, treat the local version as unknown.
+
+#### 3.2 Fetch remote version
+
+Check if the project's GitHub repository ships `.oss-ai-helper-rules/` with a version:
+
+```bash
+gh api repos/<org>/<repo>/contents/.oss-ai-helper-rules/project-info.md --jq '.content' 2>/dev/null | base64 -d | grep -A1 '## Version'
+```
+
+If the remote `.oss-ai-helper-rules/` directory does not exist, or the remote files have no `## Version` section, skip the version check and continue with the command.
+
+#### 3.3 Compare versions
+
+If the remote version differs from the local version (or the local version is unknown):
+
+1. Inform the user:
+   > Project rules update available. Local version: `<local-version>`, remote version: `<remote-version>`.
+
+2. **Ask the user to confirm** before updating:
+   > Do you want to update the local rules to the latest version from the repository?
+
+3. If the user confirms:
+   - Download all three rule files from the remote `.oss-ai-helper-rules/` directory
+   - Overwrite the local rule files (in `.oss-ai-helper-rules/` or `rules/<project>/` depending on where they were loaded from)
+   - Re-read the updated rule files before continuing with the command
+
+4. If the user declines, continue with the existing local rules.

--- a/commands/oss-add-project.md
+++ b/commands/oss-add-project.md
@@ -1,6 +1,6 @@
 # Add New Project
 
-Register a new project with the AI Agents OSS Helper by adding its configuration to the rule files.
+Add a new project to the AI Agents OSS Helper by adding its configuration to the rule files.
 
 ## Usage
 
@@ -38,7 +38,41 @@ From the description, identify:
 
 Ask the user to confirm or provide any missing details.
 
-### 3. Create Rule Files
+### 3. Check for Existing and Project-Provided Rules
+
+#### 3.1 Check if rules already exist locally
+
+Check if `rules/<project>/` already exists with rule files. If it does, read the `## Version` section from the local `project-info.md` to get the local version.
+
+#### 3.2 Check remote repository for `.oss-ai-helper-rules/`
+
+Check if the GitHub repository already ships `.oss-ai-helper-rules/`:
+
+```bash
+gh api repos/<org>/<repo>/contents/.oss-ai-helper-rules --jq '.[].name' 2>/dev/null
+```
+
+If the directory exists and contains rule files (`project-info.md`, `project-standards.md`, `project-guidelines.md`):
+
+- If rules **already exist locally**: compare the `## Version` from the remote `project-info.md` against the local version. If versions differ, inform the user:
+  > Project rules update available. Local version: `<local-version>`, remote version: `<remote-version>`. Do you want to update?
+
+  Only proceed with the download if the user confirms. If the user declines, skip to the end.
+
+- If rules **do not exist locally**: download them directly into `rules/<project>/`:
+
+```bash
+mkdir -p rules/<project>
+gh api repos/<org>/<repo>/contents/.oss-ai-helper-rules/project-info.md --jq '.content' | base64 -d > rules/<project>/project-info.md
+gh api repos/<org>/<repo>/contents/.oss-ai-helper-rules/project-standards.md --jq '.content' | base64 -d > rules/<project>/project-standards.md
+gh api repos/<org>/<repo>/contents/.oss-ai-helper-rules/project-guidelines.md --jq '.content' | base64 -d > rules/<project>/project-guidelines.md
+```
+
+After downloading, skip to **step 5** (Update install.sh) - no need to create rule files manually.
+
+If the remote `.oss-ai-helper-rules/` directory does not exist or is incomplete, proceed to step 4 to create them.
+
+### 4. Create Rule Files
 
 Create a new subdirectory under `rules/` named after the project (e.g., `rules/my-project/`) and add three rule files:
 
@@ -48,36 +82,51 @@ Create with:
 - Intro paragraph (same as other project-info files)
 - Remote pattern
 - GitHub repo
-- Issue tracker type and URL
-- Issue ID format
+- Issue tracker type (GitHub or Jira)
+- Issue tracker URL
+- Issue ID format (numeric or alphanumeric)
 - SonarCloud component key
 - Documentation URL
 - Related repositories
-- Create-issue support
+- Create-issue supported (yes/no)
+- `## Version` section with the current git SHA of the project being configured
 
 #### B. `rules/<project>/project-standards.md`
 Create with:
 - H1 heading: `# Project Standards`
 - Intro paragraph (same as other project-standards files)
 - Build tool
-- Build/test/format commands
-- Module-specific build rules
-- Parallelized Maven flag
+- Build command
+- Test command
+- Test with coverage command
+- Format command
+- Module-specific build (yes/no)
+- Parallelized Maven (yes/no/n/a)
 - Code style restrictions
+- `## Version` section with the current git SHA of the project being configured
 
 #### C. `rules/<project>/project-guidelines.md`
 Create with:
 - H1 heading: `# Project Guidelines`
 - Intro paragraph (same as other project-guidelines files)
-- Branch naming patterns
-- Commit message formats
-- PR creation policy
-- Find-task labels/JQL
+- Fix-issue branch naming pattern
+- Quick-fix branch naming pattern
+- SonarCloud branch naming pattern
+- Commit format (fix-issue)
+- Commit format (quick-fix)
+- CI-fix branch naming pattern
+- Commit format (ci-fix)
+- PR creation policy (always/on request)
+- Find-task source (GitHub labels or Jira JQL)
+- Find-task beginner label
+- Find-task intermediate label
+- Find-task experienced label
 - Scope-too-large redirect
+- `## Version` section with the current git SHA of the project being configured
 
-Use existing project files (e.g., `rules/wanaku/`) as a template for the format.
+Use existing project files (e.g., `rules/wanaku/`) as a template for the exact format.
 
-### 4. Update install.sh
+### 5. Update install.sh
 
 Add the three new rule file paths to the `RULE_FILES` array in `install.sh`:
 ```
@@ -86,29 +135,29 @@ Add the three new rule file paths to the `RULE_FILES` array in `install.sh`:
 "rules/<project>/project-guidelines.md"
 ```
 
-### 5. Update Command Files
+### 6. Update .oss-init.md
 
-Add the new remote pattern -> project directory mapping to the "Detect Project" section in all command files under `commands/`.
+Add the new remote pattern -> project directory mapping to the "Installed rules" section (step 2B) in `commands/.oss-init.md`.
 
-### 6. Update README.md
+### 7. Update README.md
 
 Add the new project to the supported projects table in README.md.
 
-### 7. Constraints
+### 8. Constraints
 
 You MUST:
 - Follow the existing format of each rule file exactly (use other project directories as templates)
 - Confirm all details with the user before making changes
 - Create all three rule files in the new subdirectory
 - Update install.sh with the new file paths
-- Update the remote pattern mapping in all command files
+- Update the remote pattern mapping in `.oss-init.md`
 
 You MUST NOT:
 - Create per-project command files (all commands are generic)
 - Modify existing project directories without user consent
 - Skip creating any of the three rule files
 
-### 8. Output
+### 9. Output
 
 After adding the project, confirm:
 - Files updated

--- a/commands/oss-analyze-issue.md
+++ b/commands/oss-analyze-issue.md
@@ -13,34 +13,9 @@ Analyze an issue from the current project's issue tracker to gain deeper underst
 
 ## Instructions
 
-### 1. Detect Project
+### 1. Initialize Project Context
 
-Determine the current project by running:
-
-```bash
-git remote get-url origin
-```
-
-Match the output against the remote patterns to determine the project directory:
-- `wanaku-ai/wanaku` -> `wanaku`
-- `wanaku-ai/wanaku-capabilities-java-sdk` -> `wanaku-capabilities-java-sdk`
-- `wanaku-ai/camel-integration-capability` -> `camel-integration-capability`
-- `apache/camel` -> `camel-core`
-- `apache/camel-quarkus` -> `camel-quarkus`
-- `apache/camel-spring-boot` -> `camel-spring-boot`
-- `apache/camel-kafka-connector` -> `camel-kafka-connector`
-- `apache/camel-k` -> `camel-k`
-- `hawtio/hawtio` -> `hawtio`
-- `KaotoIO/kaoto` -> `kaoto`
-- `KaotoIO/forage` -> `forage`
-- `orpiske/ai-agents-oss-helper` -> `ai-agents-oss-helper`
-
-If no match is found, fall back to the `generic-github` rules directory. Extract the GitHub org/repo from the remote URL (e.g., `https://github.com/org/repo.git` or `git@github.com:org/repo.git` -> `org/repo`) and use it as the project's GitHub repository for all operations.
-
-Once matched, read the project's rule files from the corresponding subdirectory:
-- `<project>/project-info.md` - Repository metadata, issue tracker, related repos
-- `<project>/project-standards.md` - Build tools, commands, code style
-- `<project>/project-guidelines.md` - Branching, commits, PR policies
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
 ### 2. Parse Input
 

--- a/commands/oss-create-issue.md
+++ b/commands/oss-create-issue.md
@@ -13,34 +13,9 @@ Create a new issue in the current project's GitHub repository.
 
 ## Instructions
 
-### 1. Detect Project
+### 1. Initialize Project Context
 
-Determine the current project by running:
-
-```bash
-git remote get-url origin
-```
-
-Match the output against the remote patterns to determine the project directory:
-- `wanaku-ai/wanaku` -> `wanaku`
-- `wanaku-ai/wanaku-capabilities-java-sdk` -> `wanaku-capabilities-java-sdk`
-- `wanaku-ai/camel-integration-capability` -> `camel-integration-capability`
-- `apache/camel` -> `camel-core`
-- `apache/camel-quarkus` -> `camel-quarkus`
-- `apache/camel-spring-boot` -> `camel-spring-boot`
-- `apache/camel-kafka-connector` -> `camel-kafka-connector`
-- `apache/camel-k` -> `camel-k`
-- `hawtio/hawtio` -> `hawtio`
-- `KaotoIO/kaoto` -> `kaoto`
-- `KaotoIO/forage` -> `forage`
-- `orpiske/ai-agents-oss-helper` -> `ai-agents-oss-helper`
-
-If no match is found, fall back to the `generic-github` rules directory. Extract the GitHub org/repo from the remote URL (e.g., `https://github.com/org/repo.git` or `git@github.com:org/repo.git` -> `org/repo`) and use it as the project's GitHub repository for all operations.
-
-Once matched, read the project's rule files from the corresponding subdirectory:
-- `<project>/project-info.md` - Repository metadata, issue tracker, related repos
-- `<project>/project-standards.md` - Build tools, commands, code style
-- `<project>/project-guidelines.md` - Branching, commits, PR policies
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
 If the project's **Create-issue supported** field is "no" (e.g., Jira projects like camel-core), stop and tell the user: "Issue creation is not supported for this project. Please create the issue directly in the project's issue tracker."
 

--- a/commands/oss-find-task.md
+++ b/commands/oss-find-task.md
@@ -10,34 +10,9 @@ Help users find an issue to contribute to the current project.
 
 ## Instructions
 
-### 1. Detect Project
+### 1. Initialize Project Context
 
-Determine the current project by running:
-
-```bash
-git remote get-url origin
-```
-
-Match the output against the remote patterns to determine the project directory:
-- `wanaku-ai/wanaku` -> `wanaku`
-- `wanaku-ai/wanaku-capabilities-java-sdk` -> `wanaku-capabilities-java-sdk`
-- `wanaku-ai/camel-integration-capability` -> `camel-integration-capability`
-- `apache/camel` -> `camel-core`
-- `apache/camel-quarkus` -> `camel-quarkus`
-- `apache/camel-spring-boot` -> `camel-spring-boot`
-- `apache/camel-kafka-connector` -> `camel-kafka-connector`
-- `apache/camel-k` -> `camel-k`
-- `hawtio/hawtio` -> `hawtio`
-- `KaotoIO/kaoto` -> `kaoto`
-- `KaotoIO/forage` -> `forage`
-- `orpiske/ai-agents-oss-helper` -> `ai-agents-oss-helper`
-
-If no match is found, fall back to the `generic-github` rules directory. Extract the GitHub org/repo from the remote URL (e.g., `https://github.com/org/repo.git` or `git@github.com:org/repo.git` -> `org/repo`) and use it as the project's GitHub repository for all operations.
-
-Once matched, read the project's rule files from the corresponding subdirectory:
-- `<project>/project-info.md` - Repository metadata, issue tracker, related repos
-- `<project>/project-standards.md` - Build tools, commands, code style
-- `<project>/project-guidelines.md` - Branching, commits, PR policies
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
 ### 2. Understand the User's Experience
 

--- a/commands/oss-fix-ci-errors.md
+++ b/commands/oss-fix-ci-errors.md
@@ -13,34 +13,9 @@ Download CI build reports, identify errors, and fix them properly.
 
 ## Instructions
 
-### 1. Detect Project
+### 1. Initialize Project Context
 
-Determine the current project by running:
-
-```bash
-git remote get-url origin
-```
-
-Match the output against the remote patterns to determine the project directory:
-- `wanaku-ai/wanaku` -> `wanaku`
-- `wanaku-ai/wanaku-capabilities-java-sdk` -> `wanaku-capabilities-java-sdk`
-- `wanaku-ai/camel-integration-capability` -> `camel-integration-capability`
-- `apache/camel` -> `camel-core`
-- `apache/camel-quarkus` -> `camel-quarkus`
-- `apache/camel-spring-boot` -> `camel-spring-boot`
-- `apache/camel-kafka-connector` -> `camel-kafka-connector`
-- `apache/camel-k` -> `camel-k`
-- `hawtio/hawtio` -> `hawtio`
-- `KaotoIO/kaoto` -> `kaoto`
-- `KaotoIO/forage` -> `forage`
-- `orpiske/ai-agents-oss-helper` -> `ai-agents-oss-helper`
-
-If no match is found, fall back to the `generic-github` rules directory. Extract the GitHub org/repo from the remote URL (e.g., `https://github.com/org/repo.git` or `git@github.com:org/repo.git` -> `org/repo`) and use it as the project's GitHub repository for all operations.
-
-Once matched, read the project's rule files from the corresponding subdirectory:
-- `<project>/project-info.md` - Repository metadata, issue tracker, related repos
-- `<project>/project-standards.md` - Build tools, commands, code style
-- `<project>/project-guidelines.md` - Branching, commits, PR policies
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
 ### 2. Parse Input
 

--- a/commands/oss-fix-issue.md
+++ b/commands/oss-fix-issue.md
@@ -13,34 +13,9 @@ Fix an issue from the current project's issue tracker.
 
 ## Instructions
 
-### 1. Detect Project
+### 1. Initialize Project Context
 
-Determine the current project by running:
-
-```bash
-git remote get-url origin
-```
-
-Match the output against the remote patterns to determine the project directory:
-- `wanaku-ai/wanaku` -> `wanaku`
-- `wanaku-ai/wanaku-capabilities-java-sdk` -> `wanaku-capabilities-java-sdk`
-- `wanaku-ai/camel-integration-capability` -> `camel-integration-capability`
-- `apache/camel` -> `camel-core`
-- `apache/camel-quarkus` -> `camel-quarkus`
-- `apache/camel-spring-boot` -> `camel-spring-boot`
-- `apache/camel-kafka-connector` -> `camel-kafka-connector`
-- `apache/camel-k` -> `camel-k`
-- `hawtio/hawtio` -> `hawtio`
-- `KaotoIO/kaoto` -> `kaoto`
-- `KaotoIO/forage` -> `forage`
-- `orpiske/ai-agents-oss-helper` -> `ai-agents-oss-helper`
-
-If no match is found, fall back to the `generic-github` rules directory. Extract the GitHub org/repo from the remote URL (e.g., `https://github.com/org/repo.git` or `git@github.com:org/repo.git` -> `org/repo`) and use it as the project's GitHub repository for all operations.
-
-Once matched, read the project's rule files from the corresponding subdirectory:
-- `<project>/project-info.md` - Repository metadata, issue tracker, related repos
-- `<project>/project-standards.md` - Build tools, commands, code style
-- `<project>/project-guidelines.md` - Branching, commits, PR policies
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
 ### 2. Parse Input
 

--- a/commands/oss-fix-sonarcloud.md
+++ b/commands/oss-fix-sonarcloud.md
@@ -18,34 +18,9 @@ Fix SonarCloud issues in the current project's codebase.
 
 ## Instructions
 
-### 1. Detect Project
+### 1. Initialize Project Context
 
-Determine the current project by running:
-
-```bash
-git remote get-url origin
-```
-
-Match the output against the remote patterns to determine the project directory:
-- `wanaku-ai/wanaku` -> `wanaku`
-- `wanaku-ai/wanaku-capabilities-java-sdk` -> `wanaku-capabilities-java-sdk`
-- `wanaku-ai/camel-integration-capability` -> `camel-integration-capability`
-- `apache/camel` -> `camel-core`
-- `apache/camel-quarkus` -> `camel-quarkus`
-- `apache/camel-spring-boot` -> `camel-spring-boot`
-- `apache/camel-kafka-connector` -> `camel-kafka-connector`
-- `apache/camel-k` -> `camel-k`
-- `hawtio/hawtio` -> `hawtio`
-- `KaotoIO/kaoto` -> `kaoto`
-- `KaotoIO/forage` -> `forage`
-- `orpiske/ai-agents-oss-helper` -> `ai-agents-oss-helper`
-
-If no match is found, fall back to the `generic-github` rules directory. Extract the GitHub org/repo from the remote URL (e.g., `https://github.com/org/repo.git` or `git@github.com:org/repo.git` -> `org/repo`) and use it as the project's GitHub repository for all operations.
-
-Once matched, read the project's rule files from the corresponding subdirectory:
-- `<project>/project-info.md` - Repository metadata, issue tracker, related repos
-- `<project>/project-standards.md` - Build tools, commands, code style
-- `<project>/project-guidelines.md` - Branching, commits, PR policies
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
 Check the **SonarCloud component key** field in the project's `project-info.md`. If the project has no SonarCloud component key configured (shows `_(none)_`), stop and tell the user: "SonarCloud is not configured for this project."
 

--- a/commands/oss-quick-fix.md
+++ b/commands/oss-quick-fix.md
@@ -20,34 +20,9 @@ Apply a quick fix to the current project's codebase without requiring a tracked 
 
 ## Instructions
 
-### 1. Detect Project
+### 1. Initialize Project Context
 
-Determine the current project by running:
-
-```bash
-git remote get-url origin
-```
-
-Match the output against the remote patterns to determine the project directory:
-- `wanaku-ai/wanaku` -> `wanaku`
-- `wanaku-ai/wanaku-capabilities-java-sdk` -> `wanaku-capabilities-java-sdk`
-- `wanaku-ai/camel-integration-capability` -> `camel-integration-capability`
-- `apache/camel` -> `camel-core`
-- `apache/camel-quarkus` -> `camel-quarkus`
-- `apache/camel-spring-boot` -> `camel-spring-boot`
-- `apache/camel-kafka-connector` -> `camel-kafka-connector`
-- `apache/camel-k` -> `camel-k`
-- `hawtio/hawtio` -> `hawtio`
-- `KaotoIO/kaoto` -> `kaoto`
-- `KaotoIO/forage` -> `forage`
-- `orpiske/ai-agents-oss-helper` -> `ai-agents-oss-helper`
-
-If no match is found, fall back to the `generic-github` rules directory. Extract the GitHub org/repo from the remote URL (e.g., `https://github.com/org/repo.git` or `git@github.com:org/repo.git` -> `org/repo`) and use it as the project's GitHub repository for all operations.
-
-Once matched, read the project's rule files from the corresponding subdirectory:
-- `<project>/project-info.md` - Repository metadata, issue tracker, related repos
-- `<project>/project-standards.md` - Build tools, commands, code style
-- `<project>/project-guidelines.md` - Branching, commits, PR policies
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
 ### 2. Parse Input
 

--- a/commands/oss-update-knowledge.md
+++ b/commands/oss-update-knowledge.md
@@ -20,34 +20,9 @@ Update a project's rule files when project conventions change (e.g., new build t
 
 ## Instructions
 
-### 1. Detect Project
+### 1. Initialize Project Context
 
-Determine the current project by running:
-
-```bash
-git remote get-url origin
-```
-
-Match the output against the remote patterns to determine the project directory:
-- `wanaku-ai/wanaku` -> `wanaku`
-- `wanaku-ai/wanaku-capabilities-java-sdk` -> `wanaku-capabilities-java-sdk`
-- `wanaku-ai/camel-integration-capability` -> `camel-integration-capability`
-- `apache/camel` -> `camel-core`
-- `apache/camel-quarkus` -> `camel-quarkus`
-- `apache/camel-spring-boot` -> `camel-spring-boot`
-- `apache/camel-kafka-connector` -> `camel-kafka-connector`
-- `apache/camel-k` -> `camel-k`
-- `hawtio/hawtio` -> `hawtio`
-- `KaotoIO/kaoto` -> `kaoto`
-- `KaotoIO/forage` -> `forage`
-- `orpiske/ai-agents-oss-helper` -> `ai-agents-oss-helper`
-
-If no match is found, fall back to the `generic-github` rules directory. Extract the GitHub org/repo from the remote URL (e.g., `https://github.com/org/repo.git` or `git@github.com:org/repo.git` -> `org/repo`) and use it as the project's GitHub repository for all operations.
-
-Once matched, read the project's rule files from the corresponding subdirectory:
-- `<project>/project-info.md` - Repository metadata, issue tracker, related repos
-- `<project>/project-standards.md` - Build tools, commands, code style
-- `<project>/project-guidelines.md` - Branching, commits, PR policies
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
 ### 2. Parse Input
 

--- a/install.sh
+++ b/install.sh
@@ -18,13 +18,14 @@ AGENTS=("claude" "bob" "gemini")
 
 # Command files to install (relative paths from repo root)
 COMMAND_FILES=(
+    "commands/.oss-init.md"
+    "commands/oss-add-project.md"
     "commands/oss-fix-issue.md"
     "commands/oss-find-task.md"
     "commands/oss-create-issue.md"
     "commands/oss-quick-fix.md"
     "commands/oss-analyze-issue.md"
     "commands/oss-fix-sonarcloud.md"
-    "commands/oss-add-project.md"
     "commands/oss-update-knowledge.md"
     "commands/oss-fix-ci-errors.md"
 )
@@ -304,6 +305,8 @@ main() {
     for file in "${COMMAND_FILES[@]}"; do
         local filename
         filename="$(basename "$file" .md)"
+        # Skip hidden preamble files (not user-invocable)
+        [[ "$filename" == .* ]] && continue
         echo "  /$filename"
     done
 }

--- a/rules/ai-agents-oss-helper/project-guidelines.md
+++ b/rules/ai-agents-oss-helper/project-guidelines.md
@@ -15,3 +15,6 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Find-task experienced label:** `help wanted`
 - **Find-task intermediate:** _(none)_
 - **Scope-too-large redirect:** `/oss-create-issue`
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/ai-agents-oss-helper/project-info.md
+++ b/rules/ai-agents-oss-helper/project-info.md
@@ -11,3 +11,6 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
 - **Documentation URL:** _(none)_
 - **Related repositories:** _(none)_
 - **Create-issue supported:** yes
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/ai-agents-oss-helper/project-standards.md
+++ b/rules/ai-agents-oss-helper/project-standards.md
@@ -9,3 +9,6 @@ This rule file contains build tools, commands, and code style constraints for th
 - **Module-specific build:** no
 - **Parallelized Maven:** n/a
 - **Code style restrictions:** none
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-core/project-guidelines.md
+++ b/rules/camel-core/project-guidelines.md
@@ -16,3 +16,6 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Find-task intermediate:** Filter 12352792 (easy issues)
 - **Find-task experienced JQL:** `project = CAMEL AND status = Open AND labels = help-wanted` (maxResults=10)
 - **Scope-too-large redirect:** create a Jira issue directly
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-core/project-info.md
+++ b/rules/camel-core/project-info.md
@@ -11,3 +11,6 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
 - **Documentation URL:** _(none)_
 - **Related repositories:** _(none)_
 - **Create-issue supported:** no (use Jira directly)
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-core/project-standards.md
+++ b/rules/camel-core/project-standards.md
@@ -13,3 +13,6 @@ This rule file contains build tools, commands, and code style constraints for th
   - Do NOT change public API signatures without justification
   - Do NOT add new dependencies without justification
   - Maintain backwards compatibility for public APIs
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-integration-capability/project-guidelines.md
+++ b/rules/camel-integration-capability/project-guidelines.md
@@ -15,3 +15,6 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Find-task experienced label:** `help wanted`
 - **Find-task intermediate:** _(none)_
 - **Scope-too-large redirect:** `/oss-create-issue`
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-integration-capability/project-info.md
+++ b/rules/camel-integration-capability/project-info.md
@@ -11,3 +11,6 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
 - **Documentation URL:** _(none)_
 - **Related repositories:** _(none)_
 - **Create-issue supported:** yes
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-integration-capability/project-standards.md
+++ b/rules/camel-integration-capability/project-standards.md
@@ -10,3 +10,6 @@ This rule file contains build tools, commands, and code style constraints for th
 - **Module-specific build:** no (run from root)
 - **Parallelized Maven:** yes
 - **Code style restrictions:** none
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-k/project-guidelines.md
+++ b/rules/camel-k/project-guidelines.md
@@ -15,3 +15,6 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Find-task experienced label:** `help wanted`
 - **Find-task intermediate:** _(none)_
 - **Scope-too-large redirect:** `/oss-create-issue`
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-k/project-info.md
+++ b/rules/camel-k/project-info.md
@@ -12,3 +12,6 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
 - **Related repositories:**
   - `apache/camel` - Apache Camel core
 - **Create-issue supported:** yes
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-k/project-standards.md
+++ b/rules/camel-k/project-standards.md
@@ -10,3 +10,6 @@ This rule file contains build tools, commands, and code style constraints for th
 - **Parallelized Maven:** n/a
 - **Code style restrictions:**
   - Follow standard Go conventions (gofmt, go vet)
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-kafka-connector/project-guidelines.md
+++ b/rules/camel-kafka-connector/project-guidelines.md
@@ -15,3 +15,6 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Find-task experienced label:** `help wanted`
 - **Find-task intermediate:** _(none)_
 - **Scope-too-large redirect:** `/oss-create-issue`
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-kafka-connector/project-info.md
+++ b/rules/camel-kafka-connector/project-info.md
@@ -12,3 +12,6 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
 - **Related repositories:**
   - `apache/camel` - Apache Camel core
 - **Create-issue supported:** yes
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-kafka-connector/project-standards.md
+++ b/rules/camel-kafka-connector/project-standards.md
@@ -13,3 +13,6 @@ This rule file contains build tools, commands, and code style constraints for th
   - Do NOT change public API signatures without justification
   - Do NOT add new dependencies without justification
   - Maintain backwards compatibility for public APIs
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-quarkus/project-guidelines.md
+++ b/rules/camel-quarkus/project-guidelines.md
@@ -15,3 +15,6 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Find-task experienced label:** `help wanted`
 - **Find-task intermediate:** _(none)_
 - **Scope-too-large redirect:** `/oss-create-issue`
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-quarkus/project-info.md
+++ b/rules/camel-quarkus/project-info.md
@@ -12,3 +12,6 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
 - **Related repositories:**
   - `apache/camel` - Apache Camel core
 - **Create-issue supported:** yes
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-quarkus/project-standards.md
+++ b/rules/camel-quarkus/project-standards.md
@@ -13,3 +13,6 @@ This rule file contains build tools, commands, and code style constraints for th
   - Do NOT change public API signatures without justification
   - Do NOT add new dependencies without justification
   - Maintain backwards compatibility for public APIs
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-spring-boot/project-guidelines.md
+++ b/rules/camel-spring-boot/project-guidelines.md
@@ -15,3 +15,6 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Find-task intermediate:** Filter 12352792 (easy issues)
 - **Find-task experienced JQL:** `project = CAMEL AND status = Open AND labels = help-wanted` (maxResults=10)
 - **Scope-too-large redirect:** create a Jira issue directly
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-spring-boot/project-info.md
+++ b/rules/camel-spring-boot/project-info.md
@@ -12,3 +12,6 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
 - **Related repositories:**
   - `apache/camel` - Apache Camel core
 - **Create-issue supported:** no (use Jira directly)
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-spring-boot/project-standards.md
+++ b/rules/camel-spring-boot/project-standards.md
@@ -13,3 +13,6 @@ This rule file contains build tools, commands, and code style constraints for th
   - Do NOT change public API signatures without justification
   - Do NOT add new dependencies without justification
   - Maintain backwards compatibility for public APIs
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/forage/project-guidelines.md
+++ b/rules/forage/project-guidelines.md
@@ -15,3 +15,6 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Find-task experienced label:** `help wanted`
 - **Find-task intermediate:** _(none)_
 - **Scope-too-large redirect:** `/oss-create-issue`
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/forage/project-info.md
+++ b/rules/forage/project-info.md
@@ -11,3 +11,6 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
 - **Documentation URL:** _(none)_
 - **Related repositories:** _(none)_
 - **Create-issue supported:** yes
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/forage/project-standards.md
+++ b/rules/forage/project-standards.md
@@ -13,3 +13,6 @@ This rule file contains build tools, commands, and code style constraints for th
   - Do NOT change public API signatures without justification
   - Do NOT add new dependencies without justification
   - Maintain backwards compatibility for public APIs
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/generic-github/project-guidelines.md
+++ b/rules/generic-github/project-guidelines.md
@@ -15,3 +15,6 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Find-task experienced label:** `help wanted`
 - **Find-task intermediate:** _(none)_
 - **Scope-too-large redirect:** `/oss-create-issue`
+
+## Version
+0.0.1

--- a/rules/generic-github/project-info.md
+++ b/rules/generic-github/project-info.md
@@ -11,3 +11,6 @@ This rule file contains project-specific metadata used by OSS Helper commands. T
 - **Documentation URL:** _(none)_
 - **Related repositories:** _(none)_
 - **Create-issue supported:** yes
+
+## Version
+0.0.1

--- a/rules/generic-github/project-standards.md
+++ b/rules/generic-github/project-standards.md
@@ -9,3 +9,6 @@ This rule file contains build tools, commands, and code style constraints for th
 - **Module-specific build:** no
 - **Parallelized Maven:** n/a
 - **Code style restrictions:** none
+
+## Version
+0.0.1

--- a/rules/hawtio/project-guidelines.md
+++ b/rules/hawtio/project-guidelines.md
@@ -15,3 +15,6 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Find-task experienced label:** `help wanted`
 - **Find-task intermediate:** _(none)_
 - **Scope-too-large redirect:** `/oss-create-issue`
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/hawtio/project-info.md
+++ b/rules/hawtio/project-info.md
@@ -11,3 +11,6 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
 - **Documentation URL:** _(none)_
 - **Related repositories:** _(none)_
 - **Create-issue supported:** yes
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/hawtio/project-standards.md
+++ b/rules/hawtio/project-standards.md
@@ -9,3 +9,6 @@ This rule file contains build tools, commands, and code style constraints for th
 - **Module-specific build:** yes (always run `mvn` in the module directory where changes occurred)
 - **Parallelized Maven:** no (resource intensive, do NOT parallelize Maven jobs)
 - **Code style restrictions:** none
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/kaoto/project-guidelines.md
+++ b/rules/kaoto/project-guidelines.md
@@ -15,3 +15,6 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Find-task experienced label:** `help wanted`
 - **Find-task intermediate:** _(none)_
 - **Scope-too-large redirect:** `/oss-create-issue`
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/kaoto/project-info.md
+++ b/rules/kaoto/project-info.md
@@ -11,3 +11,6 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
 - **Documentation URL:** _(none)_
 - **Related repositories:** _(none)_
 - **Create-issue supported:** yes
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/kaoto/project-standards.md
+++ b/rules/kaoto/project-standards.md
@@ -9,3 +9,6 @@ This rule file contains build tools, commands, and code style constraints for th
 - **Module-specific build:** no (run from root)
 - **Parallelized Maven:** n/a
 - **Code style restrictions:** none
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/wanaku-capabilities-java-sdk/project-guidelines.md
+++ b/rules/wanaku-capabilities-java-sdk/project-guidelines.md
@@ -15,3 +15,6 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Find-task experienced label:** `help wanted`
 - **Find-task intermediate:** _(none)_
 - **Scope-too-large redirect:** `/oss-create-issue`
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/wanaku-capabilities-java-sdk/project-info.md
+++ b/rules/wanaku-capabilities-java-sdk/project-info.md
@@ -11,3 +11,6 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
 - **Documentation URL:** _(none)_
 - **Related repositories:** _(none)_
 - **Create-issue supported:** yes
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/wanaku-capabilities-java-sdk/project-standards.md
+++ b/rules/wanaku-capabilities-java-sdk/project-standards.md
@@ -10,3 +10,6 @@ This rule file contains build tools, commands, and code style constraints for th
 - **Module-specific build:** no (run from root)
 - **Parallelized Maven:** yes
 - **Code style restrictions:** none
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/wanaku/project-guidelines.md
+++ b/rules/wanaku/project-guidelines.md
@@ -15,3 +15,6 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Find-task experienced label:** `help wanted`
 - **Find-task intermediate:** _(none)_
 - **Scope-too-large redirect:** `/oss-create-issue`
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/wanaku/project-info.md
+++ b/rules/wanaku/project-info.md
@@ -13,3 +13,6 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
   - `wanaku-ai/wanaku-capabilities-java-sdk` - Capabilities SDK
   - `wanaku-ai/camel-integration-capability` - Camel integration
 - **Create-issue supported:** yes
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/wanaku/project-standards.md
+++ b/rules/wanaku/project-standards.md
@@ -10,3 +10,6 @@ This rule file contains build tools, commands, and code style constraints for th
 - **Module-specific build:** no (run from root)
 - **Parallelized Maven:** yes
 - **Code style restrictions:** none
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c


### PR DESCRIPTION
Add the ability to provide the oss-helper rules from the git project from project-local rules in `<project-root>/.oss-ai-helper-rules/` dir
+ also added version handling support for conditional update of local rules vs updated remote rules

closes #5 