### PR TITLE
Add OpenCode install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ cd ai-agents-oss-helper
 ./install.sh claude    # Claude only
 ./install.sh bob       # Bob only
 ./install.sh gemini    # Gemini CLI only
+./install.sh opencode  # OpenCode only
 ./install.sh           # All agents
 ```
 
@@ -172,6 +173,13 @@ Every command starts by processing `.oss-init.md`, which loads project rules in 
 Projects can ship their own AI helper rules by including a `.oss-ai-helper-rules/` directory in the repository root with the three rule files. This allows project maintainers to control how AI agents interact with their project, and contributors get the right configuration automatically without installing project-specific rules.
 
 If no `.oss-ai-helper-rules/` directory exists and the project isn't in the installed rules, the agent will auto-discover the project's build tool, conventions, and metadata, then generate rule files. For git repositories, rules are created in `.oss-ai-helper-rules/` so they can be committed and shared with other contributors. For non-git directories, rules are created in the central `rules/` directory.
+
+## OpenCode Notes
+
+OpenCode uses markdown command files. The installer adds frontmatter descriptions and installs commands to:
+
+- `~/.config/opencode/commands/`
+- `~/.config/opencode/rules/` (project rule files)
 
 ## Gemini CLI Notes
 

--- a/commands/.oss-init.md
+++ b/commands/.oss-init.md
@@ -59,7 +59,13 @@ If no `.oss-ai-helper-rules/` directory exists, match the git remote URL against
 - `KaotoIO/forage` -> `forage`
 - `orpiske/ai-agents-oss-helper` -> `ai-agents-oss-helper`
 
-If a match is found, read the project's rule files from the corresponding subdirectory:
+Installed rules are located under the agent's rules directory:
+- Claude: `~/.claude/rules/`
+- Bob: `~/.bob/rules/`
+- Gemini CLI: `~/.gemini/rules/`
+- OpenCode: `~/.config/opencode/rules/`
+
+If a match is found, read the project's rule files from the corresponding subdirectory under that rules directory:
 - `<project>/project-info.md` - Repository metadata, issue tracker, related repos
 - `<project>/project-standards.md` - Build tools, commands, code style
 - `<project>/project-guidelines.md` - Branching, commits, PR policies

--- a/install.sh
+++ b/install.sh
@@ -4,17 +4,18 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/YOUR_ORG/ai-agents-oss-helper/main/install.sh | bash
-#   ./install.sh              # Install to all agents (claude, bob, gemini)
+#   ./install.sh              # Install to all agents (claude, bob, gemini, opencode)
 #   ./install.sh claude       # Install to claude only
 #   ./install.sh bob          # Install to bob only
 #   ./install.sh gemini       # Install to gemini only
+#   ./install.sh opencode     # Install to opencode only
 #
 
 set -euo pipefail
 
 # Configuration
 BASE_URL="${BASE_URL:-https://raw.githubusercontent.com/orpiske/ai-agents-oss-helper/main}"
-AGENTS=("claude" "bob" "gemini")
+AGENTS=("claude" "bob" "gemini" "opencode")
 
 # Command files to install (relative paths from repo root)
 COMMAND_FILES=(
@@ -169,11 +170,49 @@ convert_md_to_toml() {
     } > "$dest"
 }
 
+# Convert a .md command file to OpenCode markdown with frontmatter
+convert_md_to_opencode_md() {
+    local src="$1"
+    local dest="$2"
+    local first_non_empty
+    local description
+
+    first_non_empty="$(awk 'NF { print; exit }' "$src")"
+    if [[ "$first_non_empty" == "---" ]]; then
+        cp "$src" "$dest"
+        return 0
+    fi
+
+    description="$(awk '
+        /^#/ { next }
+        NF { print; exit }
+    ' "$src")"
+
+    if [[ -z "$description" ]]; then
+        description="OSS Helper command"
+    fi
+
+    # Escape quotes and backslashes for YAML
+    description="$(printf '%s' "$description" | sed 's/\\/\\\\/g; s/\"/\\\"/g')"
+
+    {
+        printf -- "---\n"
+        printf 'description: "%s"\n' "$description"
+        printf -- "---\n\n"
+        cat "$src"
+    } > "$dest"
+}
+
 # Install commands for a specific agent
 install_for_agent() {
     local agent="$1"
     local commands_dir="$HOME/.$agent/commands"
     local rules_dir="$HOME/.$agent/rules"
+
+    if [[ "$agent" == "opencode" ]]; then
+        commands_dir="$HOME/.config/opencode/commands"
+        rules_dir="$HOME/.config/opencode/rules"
+    fi
 
     info "Installing for $agent..."
 
@@ -220,6 +259,21 @@ install_for_agent() {
             else
                 rm -f "$tmp_md"
                 error "    Failed to install: $toml_name"
+                return 1
+            fi
+        elif [[ "$agent" == "opencode" ]]; then
+            # OpenCode uses markdown with frontmatter in ~/.config/opencode/commands
+            local dest="$commands_dir/$filename"
+            local tmp_md
+            tmp_md="$(mktemp)"
+
+            if fetch_file "$file" "$tmp_md"; then
+                convert_md_to_opencode_md "$tmp_md" "$dest"
+                rm -f "$tmp_md"
+                info "    Installed: $filename"
+            else
+                rm -f "$tmp_md"
+                error "    Failed to install: $filename"
                 return 1
             fi
         else


### PR DESCRIPTION
## Summary
- add OpenCode as an install target in the installer
- install OpenCode commands/rules to ~/.config/opencode and add frontmatter conversion
- document OpenCode install usage and paths

## Testing
- Not run (not applicable)