### PR TITLE
Fix links pointing to old orpiske org

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Generic commands for AI coding agents (Claude, Bob, Gemini, Codex) to help contr
 | Hawtio | GitHub | `hawtio/hawtio` |
 | Kaoto | GitHub | `KaotoIO/kaoto` |
 | Forage | GitHub | `KaotoIO/forage` |
-| AI Agents OSS Helper | GitHub | `orpiske/ai-agents-oss-helper` |
+| AI Agents OSS Helper | GitHub | `Open-Harness-Engineering/ai-agents-oss-helper` |
 | Generic GitHub | GitHub | _(any unmatched GitHub repo)_ |
 
 ## Installation
@@ -25,14 +25,14 @@ Generic commands for AI coding agents (Claude, Bob, Gemini, Codex) to help contr
 ### Quick Install (All Agents)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/orpiske/ai-agents-oss-helper/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Open-Harness-Engineering/ai-agents-oss-helper/main/install.sh | bash
 ```
 
 ### Selective Install
 
 ```bash
 # Clone the repository
-git clone https://github.com/orpiske/ai-agents-oss-helper.git
+git clone https://github.com/Open-Harness-Engineering/ai-agents-oss-helper.git
 cd ai-agents-oss-helper
 
 # Install for specific agent
@@ -309,4 +309,4 @@ Apache License 2.0
 
 ---
 
-[GitHub Repository](https://github.com/orpiske/ai-agents-oss-helper)
+[GitHub Repository](https://github.com/Open-Harness-Engineering/ai-agents-oss-helper)

--- a/commands/.oss-init.md
+++ b/commands/.oss-init.md
@@ -57,7 +57,7 @@ If no `.oss-ai-helper-rules/` directory exists, match the git remote URL against
 - `hawtio/hawtio` -> `hawtio`
 - `KaotoIO/kaoto` -> `kaoto`
 - `KaotoIO/forage` -> `forage`
-- `orpiske/ai-agents-oss-helper` -> `ai-agents-oss-helper`
+- `Open-Harness-Engineering/ai-agents-oss-helper` -> `ai-agents-oss-helper`
 
 Installed rules are located under the agent's rules directory:
 - Claude: `~/.claude/rules/`

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 # Configuration
-BASE_URL="${BASE_URL:-https://raw.githubusercontent.com/orpiske/ai-agents-oss-helper/main}"
+BASE_URL="${BASE_URL:-https://raw.githubusercontent.com/Open-Harness-Engineering/ai-agents-oss-helper/main}"
 AGENTS=("claude" "bob" "gemini" "opencode" "codex")
 
 # Command files to install (relative paths from repo root)

--- a/rules/ai-agents-oss-helper/project-info.md
+++ b/rules/ai-agents-oss-helper/project-info.md
@@ -2,10 +2,10 @@
 
 This rule file contains project-specific metadata used by OSS Helper commands. Commands detect the current project by matching `git remote get-url origin` against the remote pattern below.
 
-- **Remote pattern:** `orpiske/ai-agents-oss-helper`
-- **GitHub repo:** `orpiske/ai-agents-oss-helper`
+- **Remote pattern:** `Open-Harness-Engineering/ai-agents-oss-helper`
+- **GitHub repo:** `Open-Harness-Engineering/ai-agents-oss-helper`
 - **Issue tracker:** GitHub
-- **Issue tracker URL:** `https://github.com/orpiske/ai-agents-oss-helper/issues`
+- **Issue tracker URL:** `https://github.com/Open-Harness-Engineering/ai-agents-oss-helper/issues`
 - **Issue ID format:** numeric
 - **SonarCloud component key:** _(none)_
 - **Documentation URL:** _(none)_


### PR DESCRIPTION
## Summary
- Updated all references from `orpiske/ai-agents-oss-helper` to `Open-Harness-Engineering/ai-agents-oss-helper` across `install.sh`, `commands/.oss-init.md`, `rules/ai-agents-oss-helper/project-info.md`, and `README.md`

## Test plan
- [ ] Verify `install.sh` downloads from the correct URL
- [ ] Verify project detection in `.oss-init.md` matches the new remote pattern
- [ ] Verify README links resolve correctly

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)