### PR TITLE
Fix #17: add /oss-pr-status and /oss-list-pr-status commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ cd ai-agents-oss-helper
 | `/oss-update-knowledge <source>`          | Update a project's rule files from a description or URL                 |
 | `/oss-fix-ci-errors [run-id]`             | Download CI build reports, identify errors, and fix them                |
 | `/oss-fix-backlog-task <task> repo=<path>` | Fix a task from a Backlog.md file (requires Backlog MCP server)        |
+| `/oss-pr-status [pr]`                     | Check CI checks, review state, and merge readiness of a pull request   |
+| `/oss-list-pr-status`                     | List all your open PRs with CI, review, and merge readiness summary    |
 
 All commands auto-detect the project from the current directory's git remote.
 
@@ -189,6 +191,40 @@ The command will:
 
 **Note:** Requires the Backlog MCP server to be configured and running.
 
+### Check PR Status
+
+```bash
+# Auto-detect PR from current branch
+/oss-pr-status
+
+# By PR number
+/oss-pr-status 42
+
+# By full URL
+/oss-pr-status https://github.com/org/repo/pull/42
+```
+
+The command will:
+1. Detect the current project
+2. Fetch PR metadata, CI check results, and reviews
+3. Present a structured status report
+4. Identify blockers (failing checks, pending reviews, conflicts)
+5. Suggest next steps (e.g., `/oss-fix-ci-errors` for failing CI)
+
+### List All Your PR Statuses
+
+```bash
+# List all your open PRs in the current project
+/oss-list-pr-status
+```
+
+The command will:
+1. Detect the current project
+2. List all your open PRs with CI, review, and merge readiness status
+3. Highlight PRs needing attention (failing CI, changes requested, conflicts)
+4. Suggest using `/oss-pr-status <number>` for detailed inspection of individual PRs
+
+
 ### Add a New Project
 
 ```bash
@@ -261,6 +297,8 @@ ai-agents-oss-helper/
 │   ├── oss-update-knowledge.md
 │   ├── oss-fix-ci-errors.md
 │   ├── oss-fix-backlog-task.md
+│   ├── oss-pr-status.md
+│   ├── oss-list-pr-status.md
 │   └── .oss-init.md                  # Shared preamble: project detection & rule loading
 └── rules/                            # Rule files (installed to ~/.{agent}/rules/)
     ├── wanaku/

--- a/commands/oss-list-pr-status.md
+++ b/commands/oss-list-pr-status.md
@@ -1,0 +1,112 @@
+# List PR Status
+
+List all your open pull requests in the current project's repository with a summary of their CI, review, and merge readiness status.
+
+## Usage
+
+```
+/oss-list-pr-status
+```
+
+**Arguments:**
+- None
+
+## Instructions
+
+### 1. Initialize Project Context
+
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
+
+### 2. Determine Current User
+
+Get the authenticated GitHub user:
+
+```bash
+gh api user --jq '.login'
+```
+
+### 3. List Open Pull Requests
+
+Fetch all open PRs authored by the current user in the project's repository:
+
+```bash
+gh pr list --repo <GITHUB_REPO> --author @me --state open --json number,title,headRefName,baseRefName,isDraft,createdAt,updatedAt,reviewDecision
+```
+
+If no open PRs are found, inform the user:
+> No open pull requests found for your account in this repository.
+
+### 4. Retrieve CI Status for Each PR
+
+For each open PR, fetch the CI check summary:
+
+```bash
+gh pr checks <PR_NUMBER> --repo <GITHUB_REPO>
+```
+
+Classify the overall CI status as:
+- **passing** - All checks passed
+- **failing** - One or more checks failed
+- **pending** - One or more checks still running, none failed
+- **none** - No CI checks configured
+
+### 5. Present Summary Table
+
+Provide a summary table of all open PRs:
+
+```markdown
+## Your Open PRs in <GITHUB_REPO>
+
+| # | Title | Branch | CI | Reviews | Draft | Updated |
+|---|-------|--------|----|---------|-------|---------|
+| <number> | <title> | <head> -> <base> | <passing/failing/pending/none> | <approved/changes requested/pending/none> | <yes/no> | <date> |
+
+**Total:** <N> open PR(s)
+```
+
+### 6. Highlight PRs Needing Attention
+
+After the table, list PRs that need action, grouped by reason:
+
+```markdown
+### Needs Attention
+
+**Failing CI:**
+- #<number> - <title> — use `/oss-pr-status <number>` for details
+
+**Changes Requested:**
+- #<number> - <title> — use `/oss-pr-status <number>` for details
+
+**Merge Conflicts:**
+- #<number> - <title> — rebase onto <base> branch
+```
+
+If all PRs are in good shape, report:
+> All your PRs are in good shape. No action needed.
+
+### 7. Suggest Next Steps
+
+- For any PR needing attention, suggest using `/oss-pr-status <number>` to get the full status report
+- For PRs with failing CI, suggest `/oss-fix-ci-errors` as a follow-up
+- For PRs with changes requested, suggest reviewing the feedback via `/oss-pr-status <number>`
+
+### 8. Constraints
+
+You MUST:
+- Only list PRs authored by the current user
+- Present all PRs in a single summary table
+- Clearly highlight PRs that need attention
+- Reference `/oss-pr-status` for detailed inspection of individual PRs
+
+You MUST NOT:
+- Merge, close, or modify any PR
+- Dismiss reviews or re-request reviews
+- Make changes to any code
+- List PRs from other authors
+
+### 9. Acceptance Criteria
+
+- All open PRs by the current user are listed with CI and review status
+- PRs needing attention are clearly highlighted with reasons
+- Next steps reference `/oss-pr-status` for detailed follow-up
+- Report is concise and easy to scan

--- a/commands/oss-pr-status.md
+++ b/commands/oss-pr-status.md
@@ -1,0 +1,134 @@
+# PR Status
+
+Check the status of a pull request in the current project's repository, including CI checks, review state, and merge readiness.
+
+## Usage
+
+```
+/oss-pr-status [pr]
+```
+
+**Arguments:**
+- `[pr]` - Pull request identifier: number (e.g., `42`), full URL, or omitted to auto-detect from the current branch
+
+## Instructions
+
+### 1. Initialize Project Context
+
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
+
+### 2. Parse Input
+
+Determine the pull request to inspect:
+
+- If a number is provided: use as-is
+- If a full URL (e.g., `https://github.com/org/repo/pull/42`): extract the number from the path
+- If omitted: detect from the current branch
+
+  ```bash
+  gh pr view --repo <GITHUB_REPO> --json number --jq '.number'
+  ```
+
+  If no PR is associated with the current branch, **STOP** and inform the user:
+  > No pull request found for the current branch. Please provide a PR number or URL.
+
+### 3. Retrieve PR Details
+
+Fetch the pull request metadata:
+
+```bash
+gh pr view <PR_NUMBER> --repo <GITHUB_REPO> --json number,title,state,isDraft,mergeable,baseRefName,headRefName,author,reviewDecision,reviewRequests,labels,milestone,createdAt,updatedAt
+```
+
+### 4. Retrieve CI Check Status
+
+Fetch the status of all CI checks:
+
+```bash
+gh pr checks <PR_NUMBER> --repo <GITHUB_REPO>
+```
+
+### 5. Retrieve Reviews
+
+Fetch review details:
+
+```bash
+gh pr view <PR_NUMBER> --repo <GITHUB_REPO> --json reviews --jq '.reviews[] | {author: .author.login, state: .state, submittedAt: .submittedAt}'
+```
+
+### 6. Retrieve Comments
+
+Fetch recent comments for context on any open discussion:
+
+```bash
+gh pr view <PR_NUMBER> --repo <GITHUB_REPO> --comments
+```
+
+### 7. Present Status Report
+
+Provide a structured status report to the user:
+
+```markdown
+## PR Status: #<NUMBER> - <TITLE>
+
+### Overview
+- **State:** <open/closed/merged>
+- **Draft:** <yes/no>
+- **Author:** <author>
+- **Branch:** <head> -> <base>
+- **Created:** <date>
+- **Updated:** <date>
+- **Mergeable:** <yes/no/conflicting>
+
+### CI Checks
+| Check | Status | Details |
+|-------|--------|---------|
+| <name> | <pass/fail/pending> | <details if failed> |
+
+**Overall:** <all passing / X of Y passing / X failing / pending>
+
+### Reviews
+- **Decision:** <approved/changes requested/review required/none>
+- <reviewer>: <state> (<date>)
+
+### Pending Actions
+<List of things blocking merge, e.g.:>
+- [ ] Failing CI checks
+- [ ] Pending reviews
+- [ ] Merge conflicts
+- [ ] Draft status
+
+### Recent Comments
+<Summary of last 3-5 comments if relevant discussion exists, otherwise "No recent discussion.">
+```
+
+### 8. Suggest Next Steps
+
+Based on the status, recommend actions:
+
+- **Failing CI checks**: Suggest `/oss-fix-ci-errors <run-id>` with the failed run ID
+- **Changes requested**: Summarize what reviewers asked for
+- **Merge conflicts**: Suggest rebasing onto the base branch
+- **Draft PR**: Suggest marking as ready for review if appropriate
+- **All clear**: Inform the user the PR is ready to merge
+
+### 9. Constraints
+
+You MUST:
+- Present all information clearly and structured
+- Include CI check details, especially for failures
+- Summarize review feedback accurately
+- Identify all blockers preventing merge
+
+You MUST NOT:
+- Merge or close the PR (status check only)
+- Modify the PR in any way
+- Dismiss reviews or re-request reviews
+- Make changes to any code
+
+### 10. Acceptance Criteria
+
+- PR status is fully reported with CI, review, and merge readiness details
+- All blocking items are clearly identified
+- Actionable next steps are suggested
+- Report is concise and easy to scan

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,8 @@ COMMAND_FILES=(
     "commands/oss-update-knowledge.md"
     "commands/oss-fix-ci-errors.md"
     "commands/oss-fix-backlog-task.md"
+    "commands/oss-pr-status.md"
+    "commands/oss-list-pr-status.md"
 )
 
 # Rule files to install (relative paths from repo root)


### PR DESCRIPTION
## Summary
- Adds `/oss-pr-status [pr]` command to check CI checks, review state, and merge readiness of a single PR
- Adds `/oss-list-pr-status` command to list all open PRs by the current user with a summary table
- Updates README.md with documentation and install.sh with new command file paths

Closes #17

## Test plan
- [x] Run `/oss-pr-status` on a branch with an open PR and verify it reports CI, reviews, and merge readiness
- [x] Run `/oss-list-pr-status` and verify it lists all open PRs with correct status summary
- [x] Run `install.sh` and verify new command files are installed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)