### PR TITLE
Fix #16: use git clone for command installation and updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.last-update-check

--- a/README.md
+++ b/README.md
@@ -28,21 +28,39 @@ Generic commands for AI coding agents (Claude, Bob, Gemini, Codex) to help contr
 curl -fsSL https://raw.githubusercontent.com/Open-Harness-Engineering/ai-agents-oss-helper/main/install.sh | bash
 ```
 
+This clones the repository to `~/.oss-helper/` and installs commands and rules for all supported agents. For Claude and Bob, commands and rules are symlinked so that updates take effect instantly.
+
 ### Selective Install
 
 ```bash
-# Clone the repository
-git clone https://github.com/Open-Harness-Engineering/ai-agents-oss-helper.git
-cd ai-agents-oss-helper
+# Install for a single agent
+curl -fsSL https://raw.githubusercontent.com/Open-Harness-Engineering/ai-agents-oss-helper/main/install.sh | bash -s claude
 
-# Install for specific agent
-./install.sh claude    # Claude only
-./install.sh bob       # Bob only
-./install.sh gemini    # Gemini CLI only
-./install.sh opencode  # OpenCode only
-./install.sh codex     # Codex only
-./install.sh           # All agents
+# Or clone first, then install
+git clone https://github.com/Open-Harness-Engineering/ai-agents-oss-helper.git ~/.oss-helper
+~/.oss-helper/install.sh claude    # Claude only
+~/.oss-helper/install.sh bob       # Bob only
+~/.oss-helper/install.sh gemini    # Gemini CLI only
+~/.oss-helper/install.sh opencode  # OpenCode only
+~/.oss-helper/install.sh codex     # Codex only
+~/.oss-helper/install.sh           # All agents
 ```
+
+### Updating
+
+Commands automatically check for updates once per day. When updates are available, you'll see a notification suggesting to run `/oss-self-update`.
+
+You can also update manually:
+
+```bash
+# From within any agent session
+/oss-self-update
+
+# Or from the command line
+cd ~/.oss-helper && git pull
+```
+
+For Claude and Bob (which use symlinks), `git pull` is all that's needed. For agents that require format conversion (Gemini, OpenCode, Codex), re-run `install.sh` after pulling.
 
 ## Available Commands
 
@@ -62,6 +80,7 @@ cd ai-agents-oss-helper
 | `/oss-pr-status [pr]`                     | Check CI checks, review state, and merge readiness of a pull request   |
 | `/oss-list-pr-status`                     | List all your open PRs with CI, review, and merge readiness summary    |
 | `/oss-backport-pr <pr> branch=<branch>`  | Cherry-pick a merged PR onto a maintenance/release branch               |
+| `/oss-self-update`                       | Update OSS Helper commands and rules to the latest version              |
 
 All commands auto-detect the project from the current directory's git remote.
 
@@ -316,6 +335,7 @@ ai-agents-oss-helper/
 │   ├── oss-pr-status.md
 │   ├── oss-list-pr-status.md
 │   ├── oss-backport-pr.md
+│   ├── oss-self-update.md
 │   └── .oss-init.md                  # Shared preamble: project detection & rule loading
 └── rules/                            # Rule files (installed to ~/.{agent}/rules/)
     ├── wanaku/

--- a/commands/.oss-init.md
+++ b/commands/.oss-init.md
@@ -228,3 +228,41 @@ If the remote version differs from the local version (or the local version is un
    - Re-read the updated rule files before continuing with the command
 
 4. If the user declines, continue with the existing local rules.
+
+### 4. Commands Version Check
+
+Check if newer OSS Helper commands are available from the remote repository.
+
+#### 4.1 Check local repository
+
+Verify the OSS Helper repository exists locally:
+
+```bash
+test -d ~/.oss-helper/.git 2>/dev/null || test -d "$(readlink -f ~/.oss-helper 2>/dev/null)/.git" 2>/dev/null
+```
+
+If neither condition is true, skip this check entirely.
+
+#### 4.2 Throttle check
+
+Only perform the remote check if the last check was more than 24 hours ago:
+
+```bash
+find ~/.oss-helper -maxdepth 1 -name ".last-update-check" -mtime -1 2>/dev/null | head -1
+```
+
+If the above command produces output (file exists and was modified within the last 24 hours), skip the rest of this step.
+
+#### 4.3 Fetch and compare
+
+```bash
+git -C ~/.oss-helper fetch --quiet 2>/dev/null
+UPDATES="$(git -C ~/.oss-helper log HEAD..origin/main --oneline 2>/dev/null)"
+touch ~/.oss-helper/.last-update-check
+```
+
+If `$UPDATES` is non-empty, briefly inform the user:
+
+> **OSS Helper update available.** Run `/oss-self-update` to update.
+
+Do NOT block or halt command execution for this notification. Continue with the requested command immediately after displaying the message.

--- a/commands/oss-self-update.md
+++ b/commands/oss-self-update.md
@@ -1,0 +1,85 @@
+# OSS Helper - Self Update
+
+Update the OSS Helper commands and rules to the latest version from the remote repository.
+
+## Usage
+
+`/oss-self-update`
+
+## Instructions
+
+### 1. Locate Repository
+
+Find the OSS Helper repository:
+
+```bash
+test -d ~/.oss-helper/.git 2>/dev/null || test -d "$(readlink -f ~/.oss-helper 2>/dev/null)/.git" 2>/dev/null
+```
+
+If `~/.oss-helper` does not exist or is not a git repository, inform the user and stop:
+
+> OSS Helper was not installed via git. Please reinstall:
+> ```
+> git clone https://github.com/orpiske/ai-agents-oss-helper.git ~/.oss-helper
+> ~/.oss-helper/install.sh
+> ```
+
+### 2. Show Available Updates
+
+Fetch the latest changes and show what is available:
+
+```bash
+git -C ~/.oss-helper fetch --quiet 2>/dev/null
+git -C ~/.oss-helper log HEAD..origin/main --oneline
+```
+
+If no output, inform the user and stop:
+
+> OSS Helper is already up to date.
+
+Otherwise, show the list of incoming changes to the user.
+
+### 3. Apply Updates
+
+Pull the latest changes:
+
+```bash
+git -C ~/.oss-helper pull --quiet
+```
+
+### 4. Re-install for Conversion Agents
+
+For agents that use symlinks (Claude, Bob), no further action is needed — the symlinks already point to the updated files.
+
+For agents that require format conversion (Gemini, OpenCode, Codex), re-run the install script to regenerate converted files:
+
+```bash
+~/.oss-helper/install.sh <agent>
+```
+
+Detect the current agent:
+- If running as a Claude command → `claude`
+- If running as a Bob command → `bob`
+- If running as a Gemini command → `gemini`
+- If running as an OpenCode command → `opencode`
+- If running as a Codex skill → `codex`
+
+For Claude and Bob, skip this step (symlinks handle it automatically).
+
+### 5. Reset Update Check
+
+Reset the update check throttle so the next check starts fresh:
+
+```bash
+touch ~/.oss-helper/.last-update-check
+```
+
+### 6. Report Results
+
+Show the user what was updated:
+
+```bash
+git -C ~/.oss-helper log --oneline -10
+```
+
+> OSS Helper updated successfully.

--- a/install.sh
+++ b/install.sh
@@ -3,19 +3,20 @@
 # Install script for AI Agent OSS Helper commands
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/YOUR_ORG/ai-agents-oss-helper/main/install.sh | bash
-#   ./install.sh              # Install to all agents (claude, bob, gemini, opencode, codex)
-#   ./install.sh claude       # Install to claude only
-#   ./install.sh bob          # Install to bob only
-#   ./install.sh gemini       # Install to gemini only
-#   ./install.sh opencode     # Install to opencode only
-#   ./install.sh codex        # Install to codex only
+#   git clone https://github.com/orpiske/ai-agents-oss-helper.git ~/.oss-helper
+#   ~/.oss-helper/install.sh              # Install to all agents (claude, bob, gemini, opencode, codex)
+#   ~/.oss-helper/install.sh claude       # Install to claude only
+#   ~/.oss-helper/install.sh bob          # Install to bob only
+#   ~/.oss-helper/install.sh gemini       # Install to gemini only
+#   ~/.oss-helper/install.sh opencode     # Install to opencode only
+#   ~/.oss-helper/install.sh codex        # Install to codex only
 #
 
 set -euo pipefail
 
 # Configuration
-BASE_URL="${BASE_URL:-https://raw.githubusercontent.com/orpiske/ai-agents-oss-helper/main}"
+REPO_URL="${REPO_URL:-https://github.com/orpiske/ai-agents-oss-helper.git}"
+INSTALL_DIR="$HOME/.oss-helper"
 AGENTS=("claude" "bob" "gemini" "opencode" "codex")
 
 # Command files to install (relative paths from repo root)
@@ -31,6 +32,7 @@ COMMAND_FILES=(
     "commands/oss-fix-sonarcloud.md"
     "commands/oss-update-knowledge.md"
     "commands/oss-fix-ci-errors.md"
+    "commands/oss-self-update.md"
 )
 
 # Rule files to install (relative paths from repo root)
@@ -124,37 +126,93 @@ error() {
     echo -e "${RED}[ERROR]${NC} $1" >&2
 }
 
-# Determine script location (for local installs)
-get_script_dir() {
+# Ensure the repository is available at INSTALL_DIR
+ensure_repo() {
+    local script_dir=""
     if [[ -n "${BASH_SOURCE[0]:-}" ]] && [[ -f "${BASH_SOURCE[0]}" ]]; then
-        cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+        script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    fi
+
+    if [[ -n "$script_dir" ]] && [[ -d "$script_dir/.git" ]]; then
+        # Running from a local git clone
+        local resolved_script resolved_install
+        resolved_script="$(cd "$script_dir" && pwd -P)"
+        resolved_install="$(cd "$INSTALL_DIR" 2>/dev/null && pwd -P 2>/dev/null || echo "")"
+
+        if [[ "$resolved_script" != "$resolved_install" ]]; then
+            # Script is not at INSTALL_DIR — link INSTALL_DIR to the clone
+            if [[ -L "$INSTALL_DIR" ]]; then
+                rm "$INSTALL_DIR"
+            elif [[ -d "$INSTALL_DIR" ]]; then
+                warn "$INSTALL_DIR already exists. Backing up to ${INSTALL_DIR}.bak"
+                mv "$INSTALL_DIR" "${INSTALL_DIR}.bak"
+            fi
+            ln -s "$script_dir" "$INSTALL_DIR"
+            info "Linked $INSTALL_DIR -> $script_dir"
+        fi
+    elif [[ -d "$INSTALL_DIR/.git" ]] || { [[ -L "$INSTALL_DIR" ]] && [[ -d "$(readlink -f "$INSTALL_DIR" 2>/dev/null)/.git" ]]; }; then
+        # INSTALL_DIR already has a repo, pull updates
+        info "Updating repository..."
+        git -C "$INSTALL_DIR" pull --quiet
     else
-        echo ""
+        # First-time install: clone the repo
+        info "Cloning repository to $INSTALL_DIR..."
+        git clone --depth 1 "$REPO_URL" "$INSTALL_DIR"
     fi
 }
 
-# Download or copy a file
+# Copy a file from the install directory
 fetch_file() {
     local src="$1"
     local dest="$2"
-    local script_dir
-    script_dir="$(get_script_dir)"
 
-    # If running locally and file exists, copy it
-    if [[ -n "$script_dir" ]] && [[ -f "$script_dir/$src" ]]; then
-        cp "$script_dir/$src" "$dest"
+    if [[ -f "$INSTALL_DIR/$src" ]]; then
+        cp "$INSTALL_DIR/$src" "$dest"
         return 0
     fi
 
-    # Otherwise, download from remote
-    if command -v curl &> /dev/null; then
-        curl -fsSL "$BASE_URL/$src" -o "$dest"
-    elif command -v wget &> /dev/null; then
-        wget -q "$BASE_URL/$src" -O "$dest"
-    else
-        error "Neither curl nor wget found. Cannot download files."
-        return 1
+    error "Source file not found: $INSTALL_DIR/$src"
+    return 1
+}
+
+# Create a symlink to a file in the install directory
+link_file() {
+    local src="$1"
+    local dest="$2"
+
+    # Resolve INSTALL_DIR to an absolute path (follow symlinks)
+    local abs_install_dir
+    abs_install_dir="$(cd "$INSTALL_DIR" && pwd -P)"
+
+    if [[ -f "$abs_install_dir/$src" ]]; then
+        ln -sf "$abs_install_dir/$src" "$dest"
+        return 0
     fi
+
+    error "Source file not found: $abs_install_dir/$src"
+    return 1
+}
+
+# Create a symlink to a directory in the install directory
+link_dir() {
+    local src="$1"
+    local dest="$2"
+
+    # Resolve INSTALL_DIR to an absolute path (follow symlinks)
+    local abs_install_dir
+    abs_install_dir="$(cd "$INSTALL_DIR" && pwd -P)"
+
+    if [[ -d "$abs_install_dir/$src" ]]; then
+        # Remove existing target (file, symlink, or directory)
+        if [[ -L "$dest" ]] || [[ -e "$dest" ]]; then
+            rm -rf "$dest"
+        fi
+        ln -s "$abs_install_dir/$src" "$dest"
+        return 0
+    fi
+
+    error "Source directory not found: $abs_install_dir/$src"
+    return 1
 }
 
 # Convert a .md command file to Gemini CLI .toml format
@@ -240,6 +298,11 @@ install_for_agent() {
     local agent="$1"
     local commands_dir="$HOME/.$agent/commands"
     local rules_dir="$HOME/.$agent/rules"
+    local use_symlinks=false
+
+    if [[ "$agent" == "claude" || "$agent" == "bob" ]]; then
+        use_symlinks=true
+    fi
 
     if [[ "$agent" == "opencode" ]]; then
         commands_dir="$HOME/.config/opencode/commands"
@@ -386,6 +449,15 @@ install_for_agent() {
                 error "    Failed to install: $filename"
                 return 1
             fi
+        elif [[ "$use_symlinks" == "true" ]]; then
+            # Claude/Bob: create symlinks for instant updates
+            local dest="$commands_dir/$filename"
+            if link_file "$file" "$dest"; then
+                info "    Linked: $filename"
+            else
+                error "    Failed to link: $filename"
+                return 1
+            fi
         else
             local dest="$commands_dir/$filename"
             if fetch_file "$file" "$dest"; then
@@ -403,26 +475,49 @@ install_for_agent() {
         rm -f "$rules_dir/$old_file"
     done
 
-    # Install rule files (with subdirectories)
+    # Install rule files
     info "  Installing rules..."
-    for file in "${RULE_FILES[@]}"; do
-        local rel_path="${file#rules/}"
-        local dest="$rules_dir/$rel_path"
-        local dest_dir
-        dest_dir="$(dirname "$dest")"
+    if [[ "$use_symlinks" == "true" ]]; then
+        # Claude/Bob: symlink entire project directories for instant updates
+        local -A linked_projects
+        for file in "${RULE_FILES[@]}"; do
+            local project
+            project="$(echo "${file#rules/}" | cut -d'/' -f1)"
+            if [[ -z "${linked_projects[$project]:-}" ]]; then
+                if link_dir "rules/$project" "$rules_dir/$project"; then
+                    info "    Linked: $project/"
+                else
+                    error "    Failed to link: $project/"
+                    return 1
+                fi
+                linked_projects[$project]=1
+            fi
+        done
+    else
+        for file in "${RULE_FILES[@]}"; do
+            local rel_path="${file#rules/}"
+            local dest="$rules_dir/$rel_path"
+            local dest_dir
+            dest_dir="$(dirname "$dest")"
 
-        mkdir -p "$dest_dir"
+            mkdir -p "$dest_dir"
 
-        if fetch_file "$file" "$dest"; then
-            info "    Installed: $rel_path"
-        else
-            error "    Failed to install: $rel_path"
-            return 1
-        fi
-    done
+            if fetch_file "$file" "$dest"; then
+                info "    Installed: $rel_path"
+            else
+                error "    Failed to install: $rel_path"
+                return 1
+            fi
+        done
+    fi
 
-    info "  Commands installed to: $commands_dir"
-    info "  Rules installed to: $rules_dir"
+    if [[ "$use_symlinks" == "true" ]]; then
+        info "  Commands linked to: $commands_dir (symlinks -> $INSTALL_DIR)"
+        info "  Rules linked to: $rules_dir (symlinks -> $INSTALL_DIR)"
+    else
+        info "  Commands installed to: $commands_dir"
+        info "  Rules installed to: $rules_dir"
+    fi
 }
 
 # Main
@@ -456,6 +551,9 @@ main() {
     echo "AI Agent OSS Helper - Installer"
     echo "================================"
     echo ""
+
+    # Ensure the git repository is available
+    ensure_repo
 
     # Install for each agent
     for agent in "${agents_to_install[@]}"; do

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,10 @@
 # Install script for AI Agent OSS Helper commands
 #
 # Usage:
-#   git clone https://github.com/orpiske/ai-agents-oss-helper.git ~/.oss-helper
+#   curl -fsSL https://raw.githubusercontent.com/Open-Harness-Engineering/ai-agents-oss-helper/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/Open-Harness-Engineering/ai-agents-oss-helper/main/install.sh | bash -s claude
+#
+#   git clone https://github.com/Open-Harness-Engineering/ai-agents-oss-helper.git ~/.oss-helper
 #   ~/.oss-helper/install.sh              # Install to all agents (claude, bob, gemini, opencode, codex)
 #   ~/.oss-helper/install.sh claude       # Install to claude only
 #   ~/.oss-helper/install.sh bob          # Install to bob only


### PR DESCRIPTION
## Summary

- Replace curl/wget download approach with git-based installation (`git clone` to `~/.oss-helper`)
- Claude/Bob get **symlinks** — updates via `git pull` take effect instantly, no re-install needed
- Gemini/OpenCode/Codex keep copy+conversion from the local clone
- Add throttled (24h) command version check in `.oss-init.md` step 4
- Add `/oss-self-update` command for in-session updates
- Add `.gitignore` for the `.last-update-check` throttle file

## Test plan

- [ ] Clone repo to `~/.oss-helper` and run `install.sh` — verify commands/rules are symlinked for Claude
- [ ] Run `install.sh` from a different clone location — verify `~/.oss-helper` symlink is created
- [ ] Run `install.sh gemini` — verify TOML conversion still works (copies, not symlinks)
- [ ] Run `install.sh codex` — verify SKILL.md conversion still works
- [ ] Verify symlinked commands are readable by Claude Code
- [ ] Verify symlinked rule directories are readable by Claude Code
- [ ] Test `/oss-self-update` command in a Claude session
- [ ] Verify throttle: version check skipped if `.last-update-check` is less than 24h old

Closes #16

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)