### PR TITLE
Fix #24: add Jira issue creation support to /oss-create-issue command

### DIFF
--- a/commands/oss-create-issue.md
+++ b/commands/oss-create-issue.md
@@ -1,6 +1,6 @@
 # Create Issue
 
-Create a new issue in the current project's GitHub repository.
+Create a new issue in the current project's issue tracker (GitHub or Jira).
 
 ## Usage
 
@@ -17,9 +17,19 @@ Create a new issue in the current project's GitHub repository.
 
 **MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
-If the project's **Create-issue supported** field is "no" (e.g., Jira projects like camel-core), stop and tell the user: "Issue creation is not supported for this project. Please create the issue directly in the project's issue tracker."
+If the project's **Create-issue supported** field is "no", stop and tell the user: "Issue creation is not supported for this project. Please create the issue directly in the project's issue tracker."
 
-### 2. Gather Issue Information
+### 2. Detect Issue Tracker Type
+
+Read the **Issue tracker** field from the project's `project-info.md`:
+- If `GitHub` -> follow the **GitHub path** (steps 3-7)
+- If `Jira` -> follow the **Jira path** (steps 8-13)
+
+---
+
+## GitHub Path
+
+### 3. Gather Issue Information (GitHub)
 
 If title not provided, ask the user for:
 - **Title** - Brief, descriptive title for the issue
@@ -32,7 +42,7 @@ Then ask for:
 - **Actual behavior** (for bugs) - What currently happens
 - **Additional context** - Any other relevant information
 
-### 3. Determine Labels
+### 4. Determine Labels (GitHub)
 
 Based on the issue type, suggest appropriate labels:
 
@@ -47,7 +57,7 @@ Based on the issue type, suggest appropriate labels:
 
 Ask the user to confirm or modify labels.
 
-### 4. Format Issue Body
+### 5. Format Issue Body (GitHub)
 
 Structure the issue body using this template:
 
@@ -75,7 +85,7 @@ Structure the issue body using this template:
 <context>
 ```
 
-### 5. Confirm with User
+### 6. Confirm with User (GitHub)
 
 Before creating, show the user:
 - Title
@@ -84,7 +94,7 @@ Before creating, show the user:
 
 Ask for confirmation to proceed.
 
-### 6. Create the Issue
+### 7. Create the Issue (GitHub)
 
 Use GitHub CLI to create the issue:
 
@@ -95,30 +105,115 @@ EOF
 )"
 ```
 
-### 7. Report Result
-
 After creation, display:
 - Issue number
 - Issue URL
 - Confirmation message
 
-### 8. Constraints
+---
+
+## Jira Path
+
+### 8. Gather Issue Information (Jira)
+
+If title not provided, ask the user for:
+- **Summary** - Concise one-line title (under 80 chars)
+
+Then ask for:
+- **Issue type** - Bug, Improvement, Task, or Wish
+- **Description** - Detailed description of the issue with:
+  - What the problem is
+  - How to reproduce (if applicable)
+  - Expected vs actual behavior (if applicable)
+  - Any relevant code references (file paths, test class names)
+- **Component(s)** - Identify the affected component(s) from the module path (e.g., `camel-kafka` -> `camel-kafka`)
+- **Priority** - Major (default), Critical (if blocking), Minor (if cosmetic/nit)
+
+### 9. Check for Duplicates (Jira)
+
+Search Jira for existing issues with similar keywords:
+
+```bash
+curl -s -H "Authorization: Bearer $JIRA_TOKEN" \
+  "<ISSUE_TRACKER_URL>rest/api/2/search?jql=project=<JIRA_PROJECT_KEY>+AND+text+~+\"<keywords>\"+AND+status+not+in+(Closed,Resolved)&maxResults=5"
+```
+
+Read the **Issue tracker URL** and **Jira project key** from the project's `project-info.md`.
+
+If potential duplicates are found, show them to the user and ask whether to proceed or link to an existing issue.
+
+If no duplicates are found, continue.
+
+### 10. Confirm with User (Jira)
+
+Before creating, present the issue details:
+- Summary
+- Issue type
+- Component(s)
+- Priority
+- Full description
+
+Ask for confirmation to proceed.
+
+### 11. Create the Issue (Jira)
+
+**Authentication:** Use the `$JIRA_TOKEN` environment variable. If not set, stop and tell the user: "The `JIRA_TOKEN` environment variable is not set. Please set it with your Jira personal access token to create issues."
+
+Create the issue via the Jira REST API:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $JIRA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "fields": {
+      "project": {"key": "<JIRA_PROJECT_KEY>"},
+      "summary": "<summary>",
+      "issuetype": {"name": "<type>"},
+      "components": [{"name": "<component>"}],
+      "priority": {"name": "<priority>"},
+      "description": "<description>"
+    }
+  }' \
+  "<ISSUE_TRACKER_URL>rest/api/2/issue"
+```
+
+Read the **Issue tracker URL** and **Jira project key** from the project's `project-info.md`.
+
+Do NOT assign the issue (leave it unassigned for anyone to pick up, unless the user says they want to work on it).
+
+### 12. Report Result (Jira)
+
+After creation, display:
+- Issue key (e.g., `CAMEL-XXXXX`)
+- Issue URL: `<ISSUE_TRACKER_URL><ISSUE_KEY>`
+- Confirmation message
+
+If the user is currently working on a PR, mention: "Created `<ISSUE_KEY>` - not linked to current work."
+
+---
+
+## General
+
+### 13. Constraints
 
 You MUST:
 - Confirm all details with the user before creating
-- Use clear, descriptive titles
-- Include relevant labels
-- Format the body properly with Markdown
+- Use clear, descriptive titles/summaries
+- For GitHub: include relevant labels
+- For Jira: check for duplicates before creating
+- Format the body/description properly
 
 You MUST NOT:
 - Create issues without user confirmation
 - Use vague or unclear titles
 - Skip gathering necessary information
 - Create duplicate issues without checking
+- For Jira: assign the issue unless the user requests it
 
-### 9. Acceptance Criteria
+### 14. Acceptance Criteria
 
-- Issue is created in the project's repository
-- Issue has appropriate title and labels
-- Issue body is well-formatted and informative
+- Issue is created in the project's issue tracker (GitHub or Jira)
+- Issue has appropriate title/summary and metadata (labels/components)
+- Issue body/description is well-formatted and informative
 - User is provided with the issue URL

--- a/rules/camel-core/project-info.md
+++ b/rules/camel-core/project-info.md
@@ -10,7 +10,8 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
 - **SonarCloud component key:** `apache_camel`
 - **Documentation URL:** _(none)_
 - **Related repositories:** _(none)_
-- **Create-issue supported:** no (use Jira directly)
+- **Jira project key:** `CAMEL`
+- **Create-issue supported:** yes
 
 ## Version
 9cff91b315de9587ebd2f353d255dd837190061c

--- a/rules/camel-spring-boot/project-info.md
+++ b/rules/camel-spring-boot/project-info.md
@@ -11,7 +11,8 @@ This rule file contains project-specific metadata used by OSS Helper commands. C
 - **Documentation URL:** _(none)_
 - **Related repositories:**
   - `apache/camel` - Apache Camel core
-- **Create-issue supported:** no (use Jira directly)
+- **Jira project key:** `CAMEL`
+- **Create-issue supported:** yes
 
 ## Version
 9cff91b315de9587ebd2f353d255dd837190061c


### PR DESCRIPTION
## Summary
- Add Jira REST API support to `/oss-create-issue` so it works for both GitHub and Jira projects
- Add `Jira project key: CAMEL` field to `camel-core` and `camel-spring-boot` project-info rules
- Change `Create-issue supported` from `no` to `yes` for both Jira projects
- Jira path includes duplicate checking via JQL, component/priority fields, and `$JIRA_TOKEN` authentication

## Test plan
- [x] Run `/oss-create-issue` in a GitHub project — verify existing behavior unchanged
- [x] Run `/oss-create-issue` in a Jira project (e.g., `apache/camel`) — verify Jira creation flow
- [x] Verify duplicate check runs before Jira issue creation
- [x] Verify missing `$JIRA_TOKEN` shows a clear error message

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)