### PR TITLE
Fix #23: default to project-local rules in .oss-ai-helper-rules/

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,17 +311,30 @@ Commands are generic and project-agnostic. Project-specific configuration is sto
 - **`project-standards.md`** - Build tools, commands, code style restrictions
 - **`project-guidelines.md`** - Branch naming, commit formats, PR policies, task labels
 
+### Project-local rules (recommended)
+
+The recommended approach is to include an `.oss-ai-helper-rules/` directory in the repository root with the three rule files. This way rules are versioned alongside the code and every contributor gets the right configuration automatically — no per-user installation of project-specific rules required.
+
+```
+my-project/
+├── .oss-ai-helper-rules/
+│   ├── project-info.md
+│   ├── project-standards.md
+│   └── project-guidelines.md
+└── ...
+```
+
+Use `/oss-add-project` to generate initial rule files for any project.
+
+### Rule loading priority
+
 Every command starts by processing `.oss-init.md`, which loads project rules in this priority order:
 
-1. **Project-local rules** - `.oss-ai-helper-rules/` directory in the repository root (highest priority, can be committed to the repo)
-2. **Installed rules** - Matching `rules/<project>/` from the installed helper (remote pattern matching)
-3. **Auto-discovery** - If no rules exist anywhere, the agent auto-discovers the project's configuration (build tool, conventions, etc.) and generates rule files (in `.oss-ai-helper-rules/` for git repos, or in the central `rules/` directory otherwise)
+1. **Project-local rules** (recommended) - `.oss-ai-helper-rules/` directory in the repository root. Highest priority, versioned with the project.
+2. **Installed rules** (fallback) - Matching `rules/<project>/` from the globally installed helper. Used when the project does not yet ship its own rules.
+3. **Auto-discovery** (fallback) - If no rules exist anywhere, the agent auto-discovers the project's configuration (build tool, conventions, etc.) and generates rule files in `.oss-ai-helper-rules/` so they can be committed and shared.
 
-### Project-local rules (`.oss-ai-helper-rules/`)
-
-Projects can ship their own AI helper rules by including a `.oss-ai-helper-rules/` directory in the repository root with the three rule files. This allows project maintainers to control how AI agents interact with their project, and contributors get the right configuration automatically without installing project-specific rules.
-
-If no `.oss-ai-helper-rules/` directory exists and the project isn't in the installed rules, the agent will auto-discover the project's build tool, conventions, and metadata, then generate rule files. For git repositories, rules are created in `.oss-ai-helper-rules/` so they can be committed and shared with other contributors. For non-git directories, rules are created in the central `rules/` directory.
+Projects are encouraged to adopt project-local rules so that configuration travels with the repository and stays in sync across all contributors and agents.
 
 ## OpenCode Notes
 

--- a/commands/.oss-init.md
+++ b/commands/.oss-init.md
@@ -43,7 +43,9 @@ If the directory exists, read the project's rule files directly from it:
 
 These project-local rules take precedence over installed rules. Proceed to **step 3** (Version Check).
 
-#### B. Installed rules (remote pattern matching)
+#### B. Installed rules (fallback via remote pattern matching)
+
+> **Note:** This project does not yet ship its own `.oss-ai-helper-rules/` directory. Consider creating one so that rules are versioned with the project and shared automatically across contributors. Use `/oss-add-project` to generate initial rule files.
 
 If no `.oss-ai-helper-rules/` directory exists, match the git remote URL against known remote patterns to determine the project rules directory:
 - `wanaku-ai/wanaku` -> `wanaku`

--- a/commands/oss-add-project.md
+++ b/commands/oss-add-project.md
@@ -74,9 +74,14 @@ If the remote `.oss-ai-helper-rules/` directory does not exist or is incomplete,
 
 ### 4. Create Rule Files
 
-Create a new subdirectory under `rules/` named after the project (e.g., `rules/my-project/`) and add three rule files:
+Determine where to create the rule files based on the current working directory:
 
-#### A. `rules/<project>/project-info.md`
+- **If you are inside the target project's repository:** Create the rules in `<repo-root>/.oss-ai-helper-rules/`. This is the **recommended** approach — rules are versioned with the project and shared automatically across all contributors and agents.
+- **If you are inside the `ai-agents-oss-helper` repository** (or not inside the target project): Create a new subdirectory under `rules/` named after the project (e.g., `rules/my-project/`). These will be installed globally as a fallback.
+
+Add three rule files to the chosen directory:
+
+#### A. `project-info.md`
 Create with:
 - H1 heading: `# Project Information`
 - Intro paragraph (same as other project-info files)
@@ -91,7 +96,7 @@ Create with:
 - Create-issue supported (yes/no)
 - `## Version` section with the current git SHA of the project being configured
 
-#### B. `rules/<project>/project-standards.md`
+#### B. `project-standards.md`
 Create with:
 - H1 heading: `# Project Standards`
 - Intro paragraph (same as other project-standards files)
@@ -105,7 +110,7 @@ Create with:
 - Code style restrictions
 - `## Version` section with the current git SHA of the project being configured
 
-#### C. `rules/<project>/project-guidelines.md`
+#### C. `project-guidelines.md`
 Create with:
 - H1 heading: `# Project Guidelines`
 - Intro paragraph (same as other project-guidelines files)
@@ -126,7 +131,14 @@ Create with:
 
 Use existing project files (e.g., `rules/wanaku/`) as a template for the exact format.
 
-### 5. Update install.sh
+### 5. Update install.sh, .oss-init.md, and README.md
+
+**If rules were created in `.oss-ai-helper-rules/` (project-local):** Skip steps 5a–5c. The rules travel with the repository and do not need global installation. Inform the user:
+> Project rules created in `.oss-ai-helper-rules/`. Review and commit them to share with other contributors.
+
+**If rules were created in `rules/<project>/` (installed rules):** Perform steps 5a–5c:
+
+#### 5a. Update install.sh
 
 Add the three new rule file paths to the `RULE_FILES` array in `install.sh`:
 ```
@@ -135,11 +147,11 @@ Add the three new rule file paths to the `RULE_FILES` array in `install.sh`:
 "rules/<project>/project-guidelines.md"
 ```
 
-### 6. Update .oss-init.md
+#### 5b. Update .oss-init.md
 
 Add the new remote pattern -> project directory mapping to the "Installed rules" section (step 2B) in `commands/.oss-init.md`.
 
-### 7. Update README.md
+#### 5c. Update README.md
 
 Add the new project to the supported projects table in README.md.
 
@@ -160,5 +172,7 @@ You MUST NOT:
 ### 9. Output
 
 After adding the project, confirm:
-- Files updated
+- Where the rule files were created (`.oss-ai-helper-rules/` or `rules/<project>/`)
+- If project-local: remind the user to commit and push the `.oss-ai-helper-rules/` directory
+- If installed: list which files were updated (`install.sh`, `.oss-init.md`, `README.md`)
 - How to use the project with existing commands (e.g., `cd my-project && /oss-fix-issue 42`)


### PR DESCRIPTION
## Summary
- Reframe README to present `.oss-ai-helper-rules/` as the recommended primary approach, with installed rules as fallback
- Add a note in `.oss-init.md` recommending project-local rules when falling back to installed rules
- Update `oss-add-project.md` to create rules in `.oss-ai-helper-rules/` when running inside the target project repo

Global rule installation is preserved as a fallback — no changes to `install.sh`.

Closes #23