### PR TITLE
Add root-level sanity build step to commit-producing commands

### DIFF
--- a/commands/oss-address-review.md
+++ b/commands/oss-address-review.md
@@ -102,9 +102,19 @@ Run the build and test commands from the project's `project-standards.md`:
 - Regenerate downstream artifacts if needed
 - Check `git status` and commit all changes
 
-### 10. Push and Reply
+### 10. Final Sanity Build
 
-#### 10.1 Commit and Push
+**For Maven projects only:** As the last step before committing, run a full-reactor compile check from the **repository root**:
+
+```bash
+mvn clean install -DskipTests
+```
+
+This catches cross-module breakage that a module-only build in step 9 would miss — especially valuable for review fixes that touch shared APIs. Tests are skipped because step 9 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
+
+### 11. Push and Reply
+
+#### 11.1 Commit and Push
 
 Commit with a message summarizing what was addressed:
 
@@ -116,13 +126,13 @@ git push
 
 Use the commit format from the project's `project-guidelines.md`.
 
-#### 10.2 Reply to Comments
+#### 11.2 Reply to Comments
 
 For each addressed comment:
 - Reply confirming the fix with a brief explanation.
 - For questions, post the drafted reply.
 
-#### 10.3 Update PR Description
+#### 11.3 Update PR Description
 
 Update the PR description to reflect any changes in approach or scope resulting from the review:
 
@@ -130,7 +140,7 @@ Update the PR description to reflect any changes in approach or scope resulting 
 gh pr edit <number> --repo <GITHUB_REPO> --body "..."
 ```
 
-### 11. Constraints
+### 12. Constraints
 
 You MUST:
 - Present all findings and proposed actions before making changes
@@ -145,7 +155,7 @@ You MUST NOT:
 - Make unrelated changes while addressing feedback
 - Reply dismissively to suggestions — acknowledge the reviewer's perspective even when declining
 
-### 12. Acceptance Criteria
+### 13. Acceptance Criteria
 
 - All blocking comments are addressed with code changes
 - All unresolved comments have replies

--- a/commands/oss-backport-pr.md
+++ b/commands/oss-backport-pr.md
@@ -125,13 +125,35 @@ If cherry-pick **fails with conflicts**:
    >
    > You may want to manually cherry-pick and resolve the conflicts.
 
-### 8. Push the Backport Branch
+### 8. Sanity Build
+
+For **Maven projects**, verify the cherry-picked commits build cleanly on the target branch before pushing. From the **repository root**:
+
+```bash
+mvn clean install -DskipTests
+```
+
+This catches API drift between the source and target branches (e.g., a method used by the backport was renamed on the target branch). Tests are skipped because backport correctness is assumed to be validated upstream; the goal here is a compile-and-wire sanity check across the full reactor.
+
+Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only).
+
+If the build fails:
+1. Inspect the failure — it usually indicates a missing dependency commit or a signature change on the target branch.
+2. Either cherry-pick the missing prerequisite commits, resolve manually, or abort:
+   ```bash
+   git checkout -
+   git branch -D backport/<PR_NUMBER>-to-<TARGET_BRANCH_SLUG>
+   ```
+   and inform the user which prerequisite is missing.
+3. Do NOT push on a failing root build.
+
+### 9. Push the Backport Branch
 
 ```bash
 git push -u origin backport/<PR_NUMBER>-to-<TARGET_BRANCH_SLUG>
 ```
 
-### 9. Create the Backport PR
+### 10. Create the Backport PR
 
 Open a pull request from the backport branch to the target branch:
 
@@ -159,7 +181,7 @@ PREOF
 
 If the `backport` label does not exist, create the PR without it rather than failing.
 
-### 10. Report Result
+### 11. Report Result
 
 Provide the user with:
 
@@ -175,7 +197,7 @@ Provide the user with:
 Use `/oss-pr-status <NEW_PR_NUMBER>` to monitor the backport PR.
 ```
 
-### 11. Constraints
+### 12. Constraints
 
 You MUST:
 - Verify the source PR is merged before attempting the backport
@@ -192,7 +214,7 @@ You MUST NOT:
 - Skip conflict resolution without informing the user
 - Create the backport PR if cherry-pick failed
 
-### 12. Acceptance Criteria
+### 13. Acceptance Criteria
 
 - Source PR is validated as merged
 - Target branch is validated as existing

--- a/commands/oss-fix-backlog-task.md
+++ b/commands/oss-fix-backlog-task.md
@@ -108,7 +108,13 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    - For projects with module-specific builds (camel-core): run formatting in the module directory first, then test
    - For other projects: run `mvn verify` from root
 
-4. **Commit**: Use the fix-issue commit format from the project's `project-guidelines.md`, replacing the issue identifier with the backlog task ID
+4. **Final Sanity Build** (Maven projects only): As the last step before committing, run a full-reactor compile check from the **repository root**:
+   ```bash
+   mvn clean install -DskipTests
+   ```
+   This catches cross-module breakage that a module-only build in step 3 would miss. Tests are skipped because step 3 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
+
+5. **Commit**: Use the fix-issue commit format from the project's `project-guidelines.md`, replacing the issue identifier with the backlog task ID
 
    **Before committing**, ask the user whether they want to sign the commit using `-S` (GPG/SSH signature) and `-s` (Signed-off-by). Then run the appropriate command:
    - If the user wants both: `git commit -S -s -m "<COMMIT_MESSAGE>"`
@@ -116,12 +122,12 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    - If the user wants only `-s`: `git commit -s -m "<COMMIT_MESSAGE>"`
    - If the user wants neither: `git commit -m "<COMMIT_MESSAGE>"`
 
-5. **Push**: Push branch to origin
+6. **Push**: Push branch to origin
    ```bash
    git push -u origin <BRANCH_NAME>
    ```
 
-6. **PR** (based on `project-guidelines.md`):
+7. **PR** (based on `project-guidelines.md`):
    - If PR creation is specified as "always" or user requests it:
      ```bash
      gh pr create --title "<COMMIT_MESSAGE>" --body "<description>"

--- a/commands/oss-fix-ci-errors.md
+++ b/commands/oss-fix-ci-errors.md
@@ -137,7 +137,13 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    - For projects with module-specific builds: run in the affected module directory
    - For other projects: run from root
 
-4. **Commit**: Use the CI-fix commit format from the project's `project-guidelines.md`
+4. **Final Sanity Build** (Maven projects only): As the last step before committing, run a full-reactor compile check from the **repository root**:
+   ```bash
+   mvn clean install -DskipTests
+   ```
+   This catches cross-module breakage that a module-only build in step 3 would miss. Tests are skipped because step 3 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
+
+5. **Commit**: Use the CI-fix commit format from the project's `project-guidelines.md`
 
    **Before committing**, ask the user whether they want to sign the commit using `-S` (GPG/SSH signature) and `-s` (Signed-off-by). Then run the appropriate command:
    - If the user wants both: `git commit -S -s -m "ci: <brief description>"`
@@ -145,12 +151,12 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    - If the user wants only `-s`: `git commit -s -m "ci: <brief description>"`
    - If the user wants neither: `git commit -m "ci: <brief description>"`
 
-5. **Push**: Push branch to origin
+6. **Push**: Push branch to origin
    ```bash
    git push -u origin ci-fix/<short-slug>
    ```
 
-6. **PR**: Create a pull request with a description listing:
+7. **PR**: Create a pull request with a description listing:
    - Link to the failed CI run
    - Errors found and fixes applied
    - Tickets created for deferred issues (if any)

--- a/commands/oss-fix-github-alert.md
+++ b/commands/oss-fix-github-alert.md
@@ -185,7 +185,13 @@ Read branch naming and PR policy from the project's `project-guidelines.md`.
 
 3. **Format & Build:** Run the build command from `project-standards.md`. Include any auto-formatting changes.
 
-4. **Commit:** Use the format:
+4. **Final Sanity Build** (Maven projects only): As the last step before committing, run a full-reactor compile check from the **repository root**:
+   ```bash
+   mvn clean install -DskipTests
+   ```
+   This catches cross-module breakage that a module-only build in step 3 would miss. Tests are skipped because step 3 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
+
+5. **Commit:** Use the format:
    ```
    Fix <type> alert <NUMBER>: <brief description>
    ```
@@ -200,12 +206,12 @@ Read branch naming and PR policy from the project's `project-guidelines.md`.
    - `-s` only: `git commit -s -m "<COMMIT_MESSAGE>"`
    - Neither: `git commit -m "<COMMIT_MESSAGE>"`
 
-5. **Push:**
+6. **Push:**
    ```bash
    git push -u origin <BRANCH_NAME>
    ```
 
-6. **PR:** If PR creation is `always` in `project-guidelines.md`, create the PR:
+7. **PR:** If PR creation is `always` in `project-guidelines.md`, create the PR:
    ```bash
    gh pr create --title "<COMMIT_MESSAGE>" --body "<description>"
    ```

--- a/commands/oss-fix-issue.md
+++ b/commands/oss-fix-issue.md
@@ -136,7 +136,13 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    - For projects with module-specific builds (camel-core): run formatting in the module directory first, then test
    - For other projects: run `mvn verify` from root
 
-4. **Commit**: Use the commit format from the project's `project-guidelines.md`
+4. **Final Sanity Build** (Maven projects only): As the last step before committing, run a full-reactor compile check from the **repository root**:
+   ```bash
+   mvn clean install -DskipTests
+   ```
+   This catches cross-module breakage that a module-only build in step 3 would miss. Tests are skipped because step 3 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
+
+5. **Commit**: Use the commit format from the project's `project-guidelines.md`
    - GitHub projects: `Fix #<ISSUE_NUMBER>: <brief description>`
    - Jira projects: `<ISSUE_ID>: <brief description of fix>`
 
@@ -146,12 +152,12 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    - If the user wants only `-s`: `git commit -s -m "<COMMIT_MESSAGE>"`
    - If the user wants neither: `git commit -m "<COMMIT_MESSAGE>"`
 
-5. **Push**: Push branch to origin
+6. **Push**: Push branch to origin
    ```bash
    git push -u origin <BRANCH_NAME>
    ```
 
-6. **PR** (based on `project-guidelines.md`):
+7. **PR** (based on `project-guidelines.md`):
    - If PR creation is specified as "always" or user requests it:
      ```bash
      gh pr create --title "<COMMIT_MESSAGE>" --body "<description>"

--- a/commands/oss-fix-sonarcloud.md
+++ b/commands/oss-fix-sonarcloud.md
@@ -101,7 +101,13 @@ Read branch naming from the project's `project-guidelines.md`.
    - **If tests pass**: Commit with the sonarcloud commit format from the project's `project-guidelines.md`
    - **If tests fail**: Skip commit, continue to next module
 
-3. **Push**: After all modules processed
+3. **Final Sanity Build** (Maven projects only): After all per-module commits are in place and before pushing, run a full-reactor compile check from the **repository root**:
+   ```bash
+   mvn clean install -DskipTests
+   ```
+   This catches cross-module breakage that per-module builds in step 2 would miss (e.g., a SonarCloud fix in module A breaks a caller in module B). Tests are skipped because step 2 already ran them per module. Run this once, not per module. Skip entirely for non-Maven projects. If the build fails, investigate and fix with an additional per-module commit before pushing — do NOT push on a failing root build.
+
+4. **Push**: After all modules processed and the sanity build passes
    ```bash
    git push -u origin <branch-name>
    ```

--- a/commands/oss-quick-fix.md
+++ b/commands/oss-quick-fix.md
@@ -76,7 +76,13 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    - For documentation-only changes, the build step may be skipped if no code was modified
    - For projects with no build tool (ai-agents-oss-helper): skip build
 
-4. **Commit**: Use the quick-fix commit format from the project's `project-guidelines.md`
+4. **Final Sanity Build** (Maven projects only, code changes only): As the last step before committing, run a full-reactor compile check from the **repository root**:
+   ```bash
+   mvn clean install -DskipTests
+   ```
+   This catches cross-module breakage that a module-only build in step 3 would miss. Skip this step for non-Maven projects and for documentation-only changes where step 3 was skipped. If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
+
+5. **Commit**: Use the quick-fix commit format from the project's `project-guidelines.md`
 
    **Before committing**, ask the user whether they want to sign the commit using `-S` (GPG/SSH signature) and `-s` (Signed-off-by). Then run the appropriate command:
    - If the user wants both: `git commit -S -s -m "chore: <brief description>"`
@@ -84,12 +90,12 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    - If the user wants only `-s`: `git commit -s -m "chore: <brief description>"`
    - If the user wants neither: `git commit -m "chore: <brief description>"`
 
-5. **Push**: Push the branch to origin
+6. **Push**: Push the branch to origin
    ```bash
    git push -u origin quick-fix/<short-slug>
    ```
 
-6. **Pull Request**: Create a pull request
+7. **Pull Request**: Create a pull request
    ```bash
    gh pr create --title "chore: <brief description>" --body "<short explanation of what was changed and why>"
    ```


### PR DESCRIPTION
## Summary

- Inserts a Maven final sanity build (`mvn clean install -DskipTests` from repo root) as the last step before committing in all 8 OSS Helper commands that produce commits
- Catches cross-module breakage that a module-only build would miss — especially relevant for projects like `camel-core`/`camel-quarkus` whose standards default to module-specific builds
- All new steps skip cleanly for non-Maven projects (Go via `make`, yarn, docs-only)

## Commands updated

| Command | Placement of sanity build |
|---|---|
| `/oss-fix-issue` | Workflow sub-step between Format & Build and Commit |
| `/oss-quick-fix` | Workflow sub-step between Format & Build and Commit |
| `/oss-fix-backlog-task` | Workflow sub-step between Format & Build and Commit |
| `/oss-fix-ci-errors` | Workflow sub-step between Format & Build and Commit |
| `/oss-fix-github-alert` | Workflow sub-step between Format & Build and Commit |
| `/oss-backport-pr` | New top-level step between cherry-pick and push (catches API drift on target branch) |
| `/oss-fix-sonarcloud` | Single sanity build before push (per-module commit loop — running per module would be wasteful) |
| `/oss-address-review` | New top-level step between Build & Verify and Push & Reply |

## Test plan

- [ ] Run `/oss-fix-issue` on a Maven project and confirm the sanity build runs from repo root before the commit step
- [ ] Run `/oss-fix-issue` on a non-Maven project (e.g. `camel-k` Go, `kaoto` yarn) and confirm the sanity build is skipped
- [ ] Run `/oss-backport-pr` and confirm the sanity build runs between cherry-pick and push
- [ ] Run `/oss-fix-sonarcloud` and confirm a single sanity build runs before push (not per module)
- [ ] Section numbering in each edited command file is contiguous (no gaps or duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)