### PR TITLE
chore: make full root-level build mandatory in /oss-fix-issue for any project type

### DIFF
--- a/commands/oss-fix-issue.md
+++ b/commands/oss-fix-issue.md
@@ -136,11 +136,23 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    - For projects with module-specific builds (camel-core): run formatting in the module directory first, then test
    - For other projects: run `mvn verify` from root
 
-4. **Final Sanity Build** (Maven projects only): As the last step before committing, run a full-reactor compile check from the **repository root**:
-   ```bash
-   mvn clean install -DskipTests
-   ```
-   This catches cross-module breakage that a module-only build in step 3 would miss. Tests are skipped because step 3 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
+4. **Full Build Sanity Check (MANDATORY before commit)**: Regardless of project type, run a full build from the **repository root** before committing. This catches cross-module breakage that a module-only build in step 3 would miss and triggers any project-wide code generation (catalogs, DSL factories, metadata mirrors, schemas, etc.) that downstream modules produce from your changes.
+
+   Pick the command based on the project's build tool (from `project-standards.md`); skip tests since step 3 already ran them:
+
+   | Build tool | Command (run from repo root) |
+   |------------|-----------------------------|
+   | Maven      | `mvn clean install -DskipTests` |
+   | Gradle     | `./gradlew build -x test` |
+   | Go (make)  | `make build` |
+   | yarn       | `yarn build` |
+   | npm        | `npm run build` |
+   | Cargo      | `cargo build` |
+   | none / docs-only | skip this step |
+
+   If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
+
+   After the build succeeds, run `git status` and inspect newly-modified files. All regenerated files that are related to the fix (catalogs, endpoint DSLs, metadata, schemas, etc.) MUST be included in the commit. Revert any unrelated regen artifacts that come from stale upstream state — do NOT commit them.
 
 5. **Commit**: Use the commit format from the project's `project-guidelines.md`
    - GitHub projects: `Fix #<ISSUE_NUMBER>: <brief description>`


### PR DESCRIPTION
## Summary

Generalize step 4 of \`commands/oss-fix-issue.md\` so the full root-level build runs for **any** project type before committing — not just Maven.

### Why

The previous step 4 (\"Final Sanity Build\") was Maven-only and explicitly told the agent to skip the step for Go, yarn, and \"docs-only\" projects. In practice this missed two failure modes that hit me on a recent Camel fix (CAMEL-23329):

1. **Cross-module breakage** that a module-only build doesn't catch.
2. **Project-wide code generation** triggered only by the root reactor — catalog mirrors, endpoint DSL factories, metadata mirrors, schemas. Skipping the root build means the commit goes out without those regenerated files, even though they're a direct consequence of the fix.

### What changed

- Renamed step 4 to **Full Build Sanity Check (MANDATORY before commit)**.
- Added a build-tool table (Maven, Gradle, Go/make, yarn, npm, Cargo) so the agent picks the right \"build, no tests\" command from \`project-standards.md\`. Only \"none / docs-only\" skips the step.
- Added an explicit post-build instruction: run \`git status\`, include any *related* regenerated files in the commit, and revert any unrelated regen artifacts that come from stale upstream state.

## Test plan

- [x] Markdown renders correctly
- [x] Verify on a Maven multi-module project (Camel) that the agent picks up regenerated catalog/DSL files after the root build
- [x] Verify on a non-Maven project (yarn or Go) that the agent now runs the root build instead of skipping