### PR TITLE
Fix #43: adopt standard git branch naming conventions

### DIFF
--- a/commands/.oss-init.md
+++ b/commands/.oss-init.md
@@ -117,12 +117,14 @@ If a CONTRIBUTING file is found, read it and extract:
 - PR policies
 
 If no CONTRIBUTING file is found, use these defaults:
-- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (fix-issue):** `#<ISSUE_NUMBER>: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (fix):** `#<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `[chore]: <brief description>`
-- **Commit format (ci-fix):** `[ci]: <brief description>`
+- **Commit format (ci-issue):** `[ci]: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`
@@ -172,10 +174,12 @@ Create with:
 Create with:
 - H1 heading: `# Project Guidelines`
 - Intro paragraph (same as other project-guidelines files)
-- Fix-issue branch naming pattern
+- Fix branch naming pattern
+- Feature branch naming pattern
+- Bugfix branch naming pattern
 - Quick-fix branch naming pattern
 - SonarCloud branch naming pattern
-- Commit format (fix-issue)
+- Commit format (fix)
 - Commit format (quick-fix)
 - CI-fix branch naming pattern
 - Commit format (ci-fix)

--- a/commands/oss-add-project.md
+++ b/commands/oss-add-project.md
@@ -114,13 +114,15 @@ Create with:
 Create with:
 - H1 heading: `# Project Guidelines`
 - Intro paragraph (same as other project-guidelines files)
-- Fix-issue branch naming pattern
+- Fix branch naming pattern
+- Feature branch naming pattern
+- Bugfix branch naming pattern
 - Quick-fix branch naming pattern
 - SonarCloud branch naming pattern
-- Commit format (fix-issue)
+- Commit format (fix)
 - Commit format (quick-fix)
-- CI-fix branch naming pattern
-- Commit format (ci-fix)
+- CI-issue branch naming pattern
+- Commit format (ci-issue)
 - PR creation policy (always/on request)
 - Find-task source (GitHub labels or Jira JQL)
 - Find-task beginner label

--- a/commands/oss-fix-backlog-task.md
+++ b/commands/oss-fix-backlog-task.md
@@ -100,7 +100,7 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    ```bash
    git checkout main && git pull && git checkout -b <BRANCH_NAME>
    ```
-   Use the fix-issue branch naming pattern from the project's `project-guidelines.md` (e.g., `ci-issue-<TASK_ID>`), replacing the issue identifier with the backlog task ID.
+   Use the fix branch naming pattern from the project's `project-guidelines.md` (e.g., `fix/<TASK_ID>`), replacing the issue identifier with the backlog task ID.
 
 2. **Implement**: Make necessary code changes
 
@@ -114,7 +114,7 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    ```
    This catches cross-module breakage that a module-only build in step 3 would miss. Tests are skipped because step 3 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
 
-5. **Commit**: Use the fix-issue commit format from the project's `project-guidelines.md`, replacing the issue identifier with the backlog task ID
+5. **Commit**: Use the fix commit format from the project's `project-guidelines.md`, replacing the issue identifier with the backlog task ID
 
    **Before committing**, ask the user whether they want to sign the commit using `-S` (GPG/SSH signature) and `-s` (Signed-off-by). Then run the appropriate command:
    - If the user wants both: `git commit -S -s -m "<COMMIT_MESSAGE>"`

--- a/commands/oss-fix-ci-errors.md
+++ b/commands/oss-fix-ci-errors.md
@@ -127,9 +127,9 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
 
 1. **Branch**: Create from main
    ```bash
-   git checkout main && git pull && git checkout -b ci-fix/<short-slug>
+   git checkout main && git pull && git checkout -b ci-issue/<short-slug>
    ```
-   Use the CI-fix branch pattern from the project's `project-guidelines.md`.
+   Use the CI-issue branch pattern from the project's `project-guidelines.md`.
 
 2. **Implement**: Apply the fixes for category A errors
 
@@ -143,7 +143,7 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    ```
    This catches cross-module breakage that a module-only build in step 3 would miss. Tests are skipped because step 3 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
 
-5. **Commit**: Use the CI-fix commit format from the project's `project-guidelines.md`
+5. **Commit**: Use the CI-issue commit format from the project's `project-guidelines.md`
 
    **Before committing**, ask the user whether they want to sign the commit using `-S` (GPG/SSH signature) and `-s` (Signed-off-by). Then run the appropriate command:
    - If the user wants both: `git commit -S -s -m "ci: <brief description>"`
@@ -153,7 +153,7 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
 
 6. **Push**: Push branch to origin
    ```bash
-   git push -u origin ci-fix/<short-slug>
+   git push -u origin ci-issue/<short-slug>
    ```
 
 7. **PR**: Create a pull request with a description listing:

--- a/commands/oss-fix-issue.md
+++ b/commands/oss-fix-issue.md
@@ -128,7 +128,7 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    ```bash
    git checkout main && git pull && git checkout -b <BRANCH_NAME>
    ```
-   Use the branch naming pattern from the project's `project-guidelines.md` (e.g., `ci-issue-<ISSUE_ID>`).
+   Use the branch naming pattern from the project's `project-guidelines.md` (e.g., `fix/<ISSUE_ID>`).
 
 2. **Implement**: Make necessary code changes
 

--- a/rules/ai-agents-oss-helper/project-guidelines.md
+++ b/rules/ai-agents-oss-helper/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** _(not configured)_
-- **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/camel-core/project-guidelines.md
+++ b/rules/camel-core/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_ID>`
+- **Fix branch:** `fix/<ISSUE_ID>`
+- **Feature branch:** `feature/<ISSUE_ID>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_ID>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** `ci-camel-4-sonarcloud-<rule>` (customizable via `branch=<name>` option)
-- **Commit format (fix-issue):** `<ISSUE_ID>: <brief description of fix>`
+- **Commit format (fix):** `<ISSUE_ID>: <brief description of fix>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **Commit format (sonarcloud):** `(chores): fix SonarCloud <rule> in <component>`
 - **PR creation:** always
 - **Find-task source:** Jira

--- a/rules/camel-integration-capability/project-guidelines.md
+++ b/rules/camel-integration-capability/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** _(not configured)_
-- **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/camel-k/project-guidelines.md
+++ b/rules/camel-k/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** _(not configured)_
-- **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/camel-kafka-connector/project-guidelines.md
+++ b/rules/camel-kafka-connector/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** _(not configured)_
-- **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/camel-quarkus/project-guidelines.md
+++ b/rules/camel-quarkus/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** _(not configured)_
-- **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/camel-spring-boot/project-guidelines.md
+++ b/rules/camel-spring-boot/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_ID>`
+- **Fix branch:** `fix/<ISSUE_ID>`
+- **Feature branch:** `feature/<ISSUE_ID>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_ID>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** _(not configured)_
-- **Commit format (fix-issue):** `<ISSUE_ID>: <brief description of fix>`
+- **Commit format (fix):** `<ISSUE_ID>: <brief description of fix>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** Jira
 - **Find-task beginner JQL:** `project = CAMEL AND status = Open AND labels = good-first-issue` (maxResults=10)

--- a/rules/forage/project-guidelines.md
+++ b/rules/forage/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** _(not configured)_
-- **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/generic-github/project-guidelines.md
+++ b/rules/generic-github/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. This is the **generic fallback** configuration used when no other project matches the git remote URL.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** _(not configured)_
-- **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/hawtio/project-guidelines.md
+++ b/rules/hawtio/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** _(not configured)_
-- **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/kaoto/project-guidelines.md
+++ b/rules/kaoto/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** _(not configured)_
-- **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/quarkus-flow/project-guidelines.md
+++ b/rules/quarkus-flow/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** _(not configured)_
-- **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/wanaku-capabilities-java-sdk/project-guidelines.md
+++ b/rules/wanaku-capabilities-java-sdk/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** _(not configured)_
-- **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`

--- a/rules/wanaku/project-guidelines.md
+++ b/rules/wanaku/project-guidelines.md
@@ -2,13 +2,15 @@
 
 This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
 
-- **Fix-issue branch:** `ci-issue-<ISSUE_NUMBER>`
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
 - **Quick-fix branch:** `quick-fix/<short-slug>`
 - **SonarCloud branch:** _(not configured)_
-- **Commit format (fix-issue):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
 - **Commit format (quick-fix):** `chore: <brief description>`
-- **CI-fix branch:** `ci-fix/<short-slug>`
-- **Commit format (ci-fix):** `ci: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`


### PR DESCRIPTION
## Summary
- Replace misleading `ci-issue-<ID>` fix-issue branch pattern with `fix/<ID>` across all 14 project guideline files
- Add `feature/<ID>-<slug>` and `bugfix/<ID>` branch patterns
- Rename `ci-fix/` to `ci-issue/` for actual CI issues
- Update commands (`.oss-init`, `oss-add-project`, `oss-fix-issue`, `oss-fix-backlog-task`, `oss-fix-ci-errors`) to reference the new naming

## Test plan
- [ ] Run `/oss-fix-issue` on a test project and verify the branch is created as `fix/<ID>`
- [ ] Run `/oss-fix-ci-errors` and verify the branch is created as `ci-issue/<slug>`
- [ ] Run `/oss-add-project` and verify the generated guideline file uses the new patterns