### PR TITLE
chore: document backport upgrade-guide policy for camel-core

### DIFF
--- a/rules/camel-core/project-guidelines.md
+++ b/rules/camel-core/project-guidelines.md
@@ -13,6 +13,7 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Commit format (ci-issue):** `ci: <brief description>`
 - **Commit format (sonarcloud):** `(chores): fix SonarCloud <rule> in <component>`
 - **PR creation:** always
+- **Backport upgrade-guide policy:** the `docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_XX.adoc` files for ALL versions live on `main` and act as the canonical history across all releases. When a PR is backported to a maintenance branch (e.g. `camel-4.18.x`, `camel-4.14.x`) and adds an upgrade-guide note for that release line, the corresponding entry must ALSO be added to the matching `camel-4x-upgrade-guide-4_XX.adoc` file on `main` — either as part of the backport workflow or in a follow-up doc-sync PR. Without this, `main`'s version-specific upgrade guides drift out of sync with what's actually shipping on the maintenance branches.
 - **Find-task source:** Jira
 - **Find-task beginner JQL:** `project = CAMEL AND status = Open AND labels = good-first-issue` (maxResults=10)
 - **Find-task intermediate:** Filter 12352792 (easy issues)


### PR DESCRIPTION
## Summary

Adds a *Backport upgrade-guide policy* line to \`rules/camel-core/project-guidelines.md\`.

## Why

Apache Camel's per-version upgrade guides (\`docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_XX.adoc\`) all live on \`main\` and act as the canonical history across all releases. Backport PRs to maintenance branches (\`camel-4.18.x\`, \`camel-4.14.x\`, ...) have historically added upgrade-guide notes only to the maintenance branch, which causes \`main\`'s per-version files to drift out of sync with what's actually shipping.

Concrete recent examples:

- CAMEL-23373 (camel-jms - Disable ObjectMessage by default) was backported to camel-4.18.x and camel-4.14.x, the upgrade-guide note was added to those branches' \`camel-4x-upgrade-guide-4_18.adoc\` / \`_4_14.adoc\`, but the same entry was never added to those files on \`main\`.
- CAMEL-23414 (camel-hazelcast - Allow customization of SerializationConfig on managed Hazelcast instances) — same drift.

A doc-sync PR (\`apache/camel#22969\`) is fixing the current drift, and this rule prevents the next one from happening: \`/oss-backport-pr\` and similar commands consult \`project-guidelines.md\` and can now act on this convention (either bundle the doc update with the backport or prompt for a follow-up doc-sync PR on \`main\`).

## Diff

\`\`\`diff
- **PR creation:** always
+ **Backport upgrade-guide policy:** the \`docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_XX.adoc\` files for ALL versions live on \`main\` and act as the canonical history across all releases. When a PR is backported to a maintenance branch (e.g. \`camel-4.18.x\`, \`camel-4.14.x\`) and adds an upgrade-guide note for that release line, the corresponding entry must ALSO be added to the matching \`camel-4x-upgrade-guide-4_XX.adoc\` file on \`main\` — either as part of the backport workflow or in a follow-up doc-sync PR. Without this, \`main\`'s version-specific upgrade guides drift out of sync with what's actually shipping on the maintenance branches.
\`\`\`

## Scope

- Only \`rules/camel-core/project-guidelines.md\`. The other camel-family projects (\`camel-quarkus\`, \`camel-spring-boot\`, \`camel-k\`, ...) don't share this same per-version-upgrade-guide structure, so the rule is not duplicated there.

---

_Claude Code on behalf of Andrea Cosentino_