### PR TITLE
Fix #55: clarify Final Sanity Build is a full reactor build (no -pl/-am)

### DIFF
--- a/commands/oss-address-review.md
+++ b/commands/oss-address-review.md
@@ -110,6 +110,8 @@ Run the build and test commands from the project's `project-standards.md`:
 mvn clean install -DskipTests
 ```
 
+This must be a **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+
 This catches cross-module breakage that a module-only build in step 9 would miss — especially valuable for review fixes that touch shared APIs. Tests are skipped because step 9 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
 
 ### 11. Push and Reply

--- a/commands/oss-fix-backlog-task.md
+++ b/commands/oss-fix-backlog-task.md
@@ -112,6 +112,8 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    ```bash
    mvn clean install -DskipTests
    ```
+   This must be a **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+
    This catches cross-module breakage that a module-only build in step 3 would miss. Tests are skipped because step 3 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
 
 5. **Commit**: Use the fix commit format from the project's `project-guidelines.md`, replacing the issue identifier with the backlog task ID

--- a/commands/oss-fix-ci-errors.md
+++ b/commands/oss-fix-ci-errors.md
@@ -141,6 +141,8 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    ```bash
    mvn clean install -DskipTests
    ```
+   This must be a **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+
    This catches cross-module breakage that a module-only build in step 3 would miss. Tests are skipped because step 3 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
 
 5. **Commit**: Use the CI-issue commit format from the project's `project-guidelines.md`

--- a/commands/oss-fix-github-alert.md
+++ b/commands/oss-fix-github-alert.md
@@ -189,6 +189,8 @@ Read branch naming and PR policy from the project's `project-guidelines.md`.
    ```bash
    mvn clean install -DskipTests
    ```
+   This must be a **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+
    This catches cross-module breakage that a module-only build in step 3 would miss. Tests are skipped because step 3 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
 
 5. **Commit:** Use the format:

--- a/commands/oss-fix-issue.md
+++ b/commands/oss-fix-issue.md
@@ -150,6 +150,8 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    | Cargo      | `cargo build` |
    | none / docs-only | skip this step |
 
+   **Critical (Maven):** This is a **full reactor build**. Do NOT add `-pl` or `-am` flags — a scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (e.g. project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+
    If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
 
    After the build succeeds, run `git status` and inspect newly-modified files. All regenerated files that are related to the fix (catalogs, endpoint DSLs, metadata, schemas, etc.) MUST be included in the commit. Revert any unrelated regen artifacts that come from stale upstream state — do NOT commit them.

--- a/commands/oss-fix-sonarcloud.md
+++ b/commands/oss-fix-sonarcloud.md
@@ -105,6 +105,8 @@ Read branch naming from the project's `project-guidelines.md`.
    ```bash
    mvn clean install -DskipTests
    ```
+   This must be a **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+
    This catches cross-module breakage that per-module builds in step 2 would miss (e.g., a SonarCloud fix in module A breaks a caller in module B). Tests are skipped because step 2 already ran them per module. Run this once, not per module. Skip entirely for non-Maven projects. If the build fails, investigate and fix with an additional per-module commit before pushing — do NOT push on a failing root build.
 
 4. **Push**: After all modules processed and the sanity build passes

--- a/commands/oss-quick-fix.md
+++ b/commands/oss-quick-fix.md
@@ -80,6 +80,8 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    ```bash
    mvn clean install -DskipTests
    ```
+   This must be a **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+
    This catches cross-module breakage that a module-only build in step 3 would miss. Skip this step for non-Maven projects and for documentation-only changes where step 3 was skipped. If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
 
 5. **Commit**: Use the quick-fix commit format from the project's `project-guidelines.md`


### PR DESCRIPTION
Closes #55.

## What

Adds an explicit "no `-pl` / no `-am`" clarification to the **Final Sanity Build** / **Full Build Sanity Check** step in every command that has one. The intent of that step has always been a full reactor build from the repo root, but the existing wording lets agents fall back to a scoped invocation like `mvn clean install -DskipTests -pl <module> -am`, which silently skips the downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) and produces a green-looking local build while CI still fails on uncommitted regen artifacts. See the issue for a concrete example (apache/camel PR #23110).

## Touched files

- `commands/oss-fix-issue.md`
- `commands/oss-fix-backlog-task.md`
- `commands/oss-quick-fix.md`
- `commands/oss-fix-github-alert.md`
- `commands/oss-fix-ci-errors.md`
- `commands/oss-fix-sonarcloud.md`
- `commands/oss-address-review.md`

Each gets the same project-agnostic note added next to its Maven sanity-build instructions:

> This must be a **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.

No behavioural change to any tool; this is a docs-only clarification of an existing step.

---
_Claude Code on behalf of Andrea Cosentino._