### PR TITLE
chore: make Final Sanity Build mandatory and prompt for test mode

### DIFF
--- a/commands/oss-address-review.md
+++ b/commands/oss-address-review.md
@@ -102,17 +102,17 @@ Run the build and test commands from the project's `project-standards.md`:
 - Regenerate downstream artifacts if needed
 - Check `git status` and commit all changes
 
-### 10. Final Sanity Build
+### 10. Final Sanity Build (MANDATORY before commit)
 
-**For Maven projects only:** As the last step before committing, run a full-reactor compile check from the **repository root**:
+**For Maven projects only:** As the last step before committing, run a full-reactor build from the **repository root**.
 
-```bash
-mvn clean install -DskipTests
-```
+**Before running, ask the user** which build to run (use `AskUserQuestion`):
+- **(a) Skip tests** (faster, step 9 already ran tests): `mvn clean install -DskipTests`
+- **(b) Run full tests** (slower, catches cross-module integration regressions): `mvn clean install`
 
-This must be a **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+Do NOT pick a default silently — wait for the user's choice. Both options run the **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
 
-This catches cross-module breakage that a module-only build in step 9 would miss — especially valuable for review fixes that touch shared APIs. Tests are skipped because step 9 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
+This catches cross-module breakage that a module-only build in step 9 would miss — especially valuable for review fixes that touch shared APIs. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
 
 ### 11. Push and Reply
 

--- a/commands/oss-backport-pr.md
+++ b/commands/oss-backport-pr.md
@@ -125,15 +125,17 @@ If cherry-pick **fails with conflicts**:
    >
    > You may want to manually cherry-pick and resolve the conflicts.
 
-### 8. Sanity Build
+### 8. Sanity Build (MANDATORY before push)
 
-For **Maven projects**, verify the cherry-picked commits build cleanly on the target branch before pushing. From the **repository root**:
+For **Maven projects**, verify the cherry-picked commits build cleanly on the target branch before pushing. From the **repository root**.
 
-```bash
-mvn clean install -DskipTests
-```
+**Before running, ask the user** which build to run (use `AskUserQuestion`):
+- **(a) Skip tests** (default for backports — backport correctness is assumed to be validated upstream; the goal is a compile-and-wire sanity check across the full reactor): `mvn clean install -DskipTests`
+- **(b) Run full tests** (slower, useful when the maintenance branch differs significantly from main): `mvn clean install`
 
-This catches API drift between the source and target branches (e.g., a method used by the backport was renamed on the target branch). Tests are skipped because backport correctness is assumed to be validated upstream; the goal here is a compile-and-wire sanity check across the full reactor.
+Do NOT pick a default silently — wait for the user's choice. Both options run the **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale.
+
+This catches API drift between the source and target branches (e.g., a method used by the backport was renamed on the target branch).
 
 Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only).
 

--- a/commands/oss-fix-backlog-task.md
+++ b/commands/oss-fix-backlog-task.md
@@ -108,13 +108,15 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    - For projects with module-specific builds (camel-core): run formatting in the module directory first, then test
    - For other projects: run `mvn verify` from root
 
-4. **Final Sanity Build** (Maven projects only): As the last step before committing, run a full-reactor compile check from the **repository root**:
-   ```bash
-   mvn clean install -DskipTests
-   ```
-   This must be a **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+4. **Final Sanity Build (MANDATORY before commit)** (Maven projects only): As the last step before committing, run a full-reactor build from the **repository root**.
 
-   This catches cross-module breakage that a module-only build in step 3 would miss. Tests are skipped because step 3 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
+   **Before running, ask the user** which build to run (use `AskUserQuestion`):
+   - **(a) Skip tests** (faster, recommended when step 3 already ran tests): `mvn clean install -DskipTests`
+   - **(b) Run full tests** (slower, catches cross-module integration regressions): `mvn clean install`
+
+   Do NOT pick a default silently — wait for the user's choice. Both options run the **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+
+   This catches cross-module breakage that a module-only build in step 3 would miss. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
 
 5. **Commit**: Use the fix commit format from the project's `project-guidelines.md`, replacing the issue identifier with the backlog task ID
 

--- a/commands/oss-fix-ci-errors.md
+++ b/commands/oss-fix-ci-errors.md
@@ -137,13 +137,15 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    - For projects with module-specific builds: run in the affected module directory
    - For other projects: run from root
 
-4. **Final Sanity Build** (Maven projects only): As the last step before committing, run a full-reactor compile check from the **repository root**:
-   ```bash
-   mvn clean install -DskipTests
-   ```
-   This must be a **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+4. **Final Sanity Build (MANDATORY before commit)** (Maven projects only): As the last step before committing, run a full-reactor build from the **repository root**.
 
-   This catches cross-module breakage that a module-only build in step 3 would miss. Tests are skipped because step 3 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
+   **Before running, ask the user** which build to run (use `AskUserQuestion`):
+   - **(a) Skip tests** (faster, recommended when step 3 already ran tests): `mvn clean install -DskipTests`
+   - **(b) Run full tests** (slower, catches cross-module integration regressions): `mvn clean install`
+
+   Do NOT pick a default silently — wait for the user's choice. Both options run the **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+
+   This catches cross-module breakage that a module-only build in step 3 would miss. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
 
 5. **Commit**: Use the CI-issue commit format from the project's `project-guidelines.md`
 

--- a/commands/oss-fix-github-alert.md
+++ b/commands/oss-fix-github-alert.md
@@ -185,13 +185,15 @@ Read branch naming and PR policy from the project's `project-guidelines.md`.
 
 3. **Format & Build:** Run the build command from `project-standards.md`. Include any auto-formatting changes.
 
-4. **Final Sanity Build** (Maven projects only): As the last step before committing, run a full-reactor compile check from the **repository root**:
-   ```bash
-   mvn clean install -DskipTests
-   ```
-   This must be a **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+4. **Final Sanity Build (MANDATORY before commit)** (Maven projects only): As the last step before committing, run a full-reactor build from the **repository root**.
 
-   This catches cross-module breakage that a module-only build in step 3 would miss. Tests are skipped because step 3 already ran them. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
+   **Before running, ask the user** which build to run (use `AskUserQuestion`):
+   - **(a) Skip tests** (faster, recommended when step 3 already ran tests): `mvn clean install -DskipTests`
+   - **(b) Run full tests** (slower, catches cross-module integration regressions): `mvn clean install`
+
+   Do NOT pick a default silently — wait for the user's choice. Both options run the **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+
+   This catches cross-module breakage that a module-only build in step 3 would miss. Skip this step entirely for non-Maven projects (Go via `make`, yarn, docs-only). If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
 
 5. **Commit:** Use the format:
    ```

--- a/commands/oss-fix-issue.md
+++ b/commands/oss-fix-issue.md
@@ -138,17 +138,21 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
 
 4. **Full Build Sanity Check (MANDATORY before commit)**: Regardless of project type, run a full build from the **repository root** before committing. This catches cross-module breakage that a module-only build in step 3 would miss and triggers any project-wide code generation (catalogs, DSL factories, metadata mirrors, schemas, etc.) that downstream modules produce from your changes.
 
-   Pick the command based on the project's build tool (from `project-standards.md`); skip tests since step 3 already ran them:
+   **Before running, ask the user** which build mode to use (use `AskUserQuestion`):
+   - **(a) Skip tests** (faster, recommended when step 3 already ran tests)
+   - **(b) Run full tests** (slower, catches cross-module integration regressions)
 
-   | Build tool | Command (run from repo root) |
-   |------------|-----------------------------|
-   | Maven      | `mvn clean install -DskipTests` |
-   | Gradle     | `./gradlew build -x test` |
-   | Go (make)  | `make build` |
-   | yarn       | `yarn build` |
-   | npm        | `npm run build` |
-   | Cargo      | `cargo build` |
-   | none / docs-only | skip this step |
+   Do NOT pick a default silently — wait for the user's choice. Then pick the command based on the project's build tool (from `project-standards.md`):
+
+   | Build tool | (a) Skip tests | (b) Full tests |
+   |------------|----------------|----------------|
+   | Maven      | `mvn clean install -DskipTests` | `mvn clean install` |
+   | Gradle     | `./gradlew build -x test` | `./gradlew build` |
+   | Go (make)  | `make build` | `make test` |
+   | yarn       | `yarn build` | `yarn build && yarn test` |
+   | npm        | `npm run build` | `npm run build && npm test` |
+   | Cargo      | `cargo build` | `cargo test` |
+   | none / docs-only | skip this step | skip this step |
 
    **Critical (Maven):** This is a **full reactor build**. Do NOT add `-pl` or `-am` flags — a scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (e.g. project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
 

--- a/commands/oss-fix-sonarcloud.md
+++ b/commands/oss-fix-sonarcloud.md
@@ -101,13 +101,15 @@ Read branch naming from the project's `project-guidelines.md`.
    - **If tests pass**: Commit with the sonarcloud commit format from the project's `project-guidelines.md`
    - **If tests fail**: Skip commit, continue to next module
 
-3. **Final Sanity Build** (Maven projects only): After all per-module commits are in place and before pushing, run a full-reactor compile check from the **repository root**:
-   ```bash
-   mvn clean install -DskipTests
-   ```
-   This must be a **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+3. **Final Sanity Build (MANDATORY before push)** (Maven projects only): After all per-module commits are in place and before pushing, run a full-reactor build from the **repository root**.
 
-   This catches cross-module breakage that per-module builds in step 2 would miss (e.g., a SonarCloud fix in module A breaks a caller in module B). Tests are skipped because step 2 already ran them per module. Run this once, not per module. Skip entirely for non-Maven projects. If the build fails, investigate and fix with an additional per-module commit before pushing — do NOT push on a failing root build.
+   **Before running, ask the user** which build to run (use `AskUserQuestion`):
+   - **(a) Skip tests** (faster, step 2 already ran tests per module): `mvn clean install -DskipTests`
+   - **(b) Run full tests** (slower, catches cross-module integration regressions): `mvn clean install`
+
+   Do NOT pick a default silently — wait for the user's choice. Both options run the **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+
+   This catches cross-module breakage that per-module builds in step 2 would miss (e.g., a SonarCloud fix in module A breaks a caller in module B). Run this once, not per module. Skip entirely for non-Maven projects. If the build fails, investigate and fix with an additional per-module commit before pushing — do NOT push on a failing root build.
 
 4. **Push**: After all modules processed and the sanity build passes
    ```bash

--- a/commands/oss-quick-fix.md
+++ b/commands/oss-quick-fix.md
@@ -76,11 +76,13 @@ Read branch naming and commit format from the project's `project-guidelines.md`.
    - For documentation-only changes, the build step may be skipped if no code was modified
    - For projects with no build tool (ai-agents-oss-helper): skip build
 
-4. **Final Sanity Build** (Maven projects only, code changes only): As the last step before committing, run a full-reactor compile check from the **repository root**:
-   ```bash
-   mvn clean install -DskipTests
-   ```
-   This must be a **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
+4. **Final Sanity Build (MANDATORY before commit)** (Maven projects only, code changes only): As the last step before committing, run a full-reactor build from the **repository root**.
+
+   **Before running, ask the user** which build to run (use `AskUserQuestion`):
+   - **(a) Skip tests** (faster, recommended when step 3 already ran tests): `mvn clean install -DskipTests`
+   - **(b) Run full tests** (slower, catches cross-module integration regressions): `mvn clean install`
+
+   Do NOT pick a default silently — wait for the user's choice. Both options run the **full reactor build** — do NOT add `-pl` or `-am` flags. A scoped build only covers the changed module and its upstream dependencies, leaving downstream generators (project-wide catalogs, DSL builder factories, metadata mirrors) stale. CI runs the full reactor build and then fails on any uncommitted regen artifacts, so the local check must match.
 
    This catches cross-module breakage that a module-only build in step 3 would miss. Skip this step for non-Maven projects and for documentation-only changes where step 3 was skipped. If the build fails, fix the issue and re-run — do NOT commit on a failing root build.
 


### PR DESCRIPTION
## Summary

- Add **MANDATORY** to the Final Sanity Build section header in all 8 fix/code-modification commands (commit-time for most; push-time for `oss-fix-sonarcloud` and `oss-backport-pr`).
- Require each command to ask the user — via `AskUserQuestion` — whether to **skip tests** (`-DskipTests`) or **run the full test suite** before kicking off the full-reactor build. Silent defaults are explicitly forbidden.
- Expand the build-tool table in `oss-fix-issue.md` to two columns (skip-tests / full-tests) so the choice is honored across Maven, Gradle, Go (make), yarn, npm, and Cargo.

Affected commands: `oss-fix-issue`, `oss-quick-fix`, `oss-fix-backlog-task`, `oss-fix-sonarcloud`, `oss-fix-ci-errors`, `oss-fix-github-alert`, `oss-address-review`, `oss-backport-pr`.

## Test plan

- [x] Visually inspect the diff in each of the 8 command files — confirm MANDATORY label and the (a)/(b) options block are present.
- [x] Invoke a fix-style command on a Maven repo and verify the assistant prompts for skip-tests vs full-tests before running the final build.
- [x] Invoke `/oss-backport-pr` and verify the same prompt appears at the Sanity Build step.
- [x] Confirm the no-`-pl`/`-am` warnings and regen rationale are still intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)