### PR TITLE
Fix #61: warn against + in git worktree names in .oss-init.md

### DIFF
--- a/commands/.oss-init.md
+++ b/commands/.oss-init.md
@@ -228,3 +228,14 @@ If the remote version differs from the local version (or the local version is un
    - Re-read the updated rule files before continuing with the command
 
 4. If the user declines, continue with the existing local rules.
+
+### 4. Worktree path safety
+
+If at any point during this command you spawn a sub-agent with `isolation: "worktree"`, create a git worktree directly (`git worktree add <path> <branch>`), or otherwise generate a filesystem path that will host a build, the **worktree path and branch name MUST NOT contain the `+` character**. Substitute `-` or `_` instead (for example `fix/CAMEL-1234_v2` rather than `fix/CAMEL-1234+v2`).
+
+**Why:** Several Maven plugins build URLs from filesystem paths and treat `+` as a URL-encoded space (per RFC 1738), which breaks file resolution. Apache Camel (`apache/camel`) is the canonical case — a worktree at `/tmp/camel+fix-123/` breaks the build of essentially every Camel module, surfacing as missing resources, failed annotation processing, or `MojoFailureException` with cryptic path errors. Other Maven-based projects can hit the same issue.
+
+**How to apply:**
+- When deriving a worktree path from an issue id, branch slug, version string, or PR title, sanitize any `+` to `-` before passing it to the worktree-creating call.
+- When passing a `branch` to `git worktree add`, ensure the branch name itself contains no `+`.
+- This applies to **every** project, not just camel-core — assume any Maven build is at risk.


### PR DESCRIPTION
## Summary

- Adds a new **Worktree path safety** section to `commands/.oss-init.md` so every OSS Helper invocation reminds the agent to never use `+` in worktree paths or in branch names passed to `git worktree add`.
- Recommends substituting `-` or `_` for `+`, both when deriving paths from issue ids / PR titles / version strings, and when manually creating worktrees.
- Frames the rule as project-agnostic (any Maven build can be affected), with `apache/camel` called out as the canonical breakage case.

## Why

Several Maven plugins build URLs from filesystem paths and treat `+` as a URL-encoded space (RFC 1738), which breaks file resolution. A worktree at `/tmp/camel+fix-123/` breaks the build of essentially every Camel module — usually as missing resources, failed annotation processing, or a `MojoFailureException` with a cryptic path error. Putting the warning in `.oss-init.md` means every command picks it up via the mandatory init step.

Fixes #61.

## Test plan

- [x] Diff inspected — only `commands/.oss-init.md` is touched.
- [x] No build to run for this repo (Markdown/shell only, per project standards).
- [ ] Next OSS Helper invocation should display the new "Worktree path safety" section in its init context.