### PR TITLE
Fix #16: use git clone for installation with symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+known-projects/
+.last-update-check

--- a/install.sh
+++ b/install.sh
@@ -4,18 +4,22 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/Open-Harness-Engineering/ai-agents-oss-helper/main/install.sh | bash
-#   ./install.sh              # Install to all agents (claude, bob, gemini, opencode, codex)
-#   ./install.sh claude       # Install to claude only
-#   ./install.sh bob          # Install to bob only
-#   ./install.sh gemini       # Install to gemini only
-#   ./install.sh opencode     # Install to opencode only
-#   ./install.sh codex        # Install to codex only
+#
+#   git clone https://github.com/Open-Harness-Engineering/ai-agents-oss-helper.git ~/.oss-helper
+#   ~/.oss-helper/install.sh              # Install to all agents (claude, bob, gemini, opencode, codex)
+#   ~/.oss-helper/install.sh claude       # Install to claude only
 #
 
 set -euo pipefail
 
 # Configuration
+REPO_URL="${REPO_URL:-https://github.com/Open-Harness-Engineering/ai-agents-oss-helper.git}"
+KNOWN_PROJECTS_ORG_REPO="${OSS_KNOWN_PROJECTS_REPO:-Open-Harness-Engineering/ai-agents-oss-known-projects}"
+KNOWN_PROJECTS_BRANCH="${OSS_KNOWN_PROJECTS_BRANCH:-main}"
+KNOWN_PROJECTS_REPO_URL="https://github.com/${KNOWN_PROJECTS_ORG_REPO}.git"
 BASE_URL="${BASE_URL:-https://raw.githubusercontent.com/Open-Harness-Engineering/ai-agents-oss-helper/main}"
+INSTALL_DIR="$HOME/.oss-helper"
+KNOWN_PROJECTS_DIR="$INSTALL_DIR/known-projects"
 AGENTS=("claude" "bob" "gemini" "opencode" "codex")
 
 # Shared initialization file (copied into each skill directory during install)
@@ -83,6 +87,7 @@ SKILL_FILES[oss-project]="
     skills/oss-project/add-project.md
     skills/oss-project/install-info.md
     skills/oss-project/oss-create-rules.md
+    skills/oss-project/self-update.md
     skills/oss-project/update-knowledge.md
     skills/oss-project/oss-workspace-init.md
     skills/oss-project/oss-workspace-status.md
@@ -126,6 +131,7 @@ GUIDELINE_COMMANDS=(
     "oss-project|add-project.md|oss-add-project|Add a new project to the OSS Helper"
     "oss-project|install-info.md|oss-install-info|Install project rules from the known-projects repository"
     "oss-project|oss-create-rules.md|oss-create-rules|Generate project rule files by auto-inspecting a repository"
+    "oss-project|self-update.md|oss-self-update|Update the OSS Helper itself"
     "oss-project|update-knowledge.md|oss-update-knowledge|Update project rule files"
     "oss-project|oss-workspace-init.md|oss-workspace-init|Initialize a multi-repo workspace"
     "oss-project|oss-workspace-status.md|oss-workspace-status|Report status of all repos in a workspace"
@@ -187,6 +193,7 @@ OLD_COMMAND_FILES=(
     "oss-quick-fix.md"
     "oss-review-pr.md"
     "oss-triage-security-report.md"
+    "oss-self-update.md"
     "oss-update-knowledge.md"
     "oss-create-rules.md"
     "oss-triage-issue.md"
@@ -252,37 +259,139 @@ error() {
     echo -e "${RED}[ERROR]${NC} $1" >&2
 }
 
-# Determine script location (for local installs)
-get_script_dir() {
+# Ensure the oss-helper repository is available at INSTALL_DIR
+ensure_repo() {
+    local script_dir=""
     if [[ -n "${BASH_SOURCE[0]:-}" ]] && [[ -f "${BASH_SOURCE[0]}" ]]; then
-        cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+        script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    fi
+
+    if [[ -n "$script_dir" ]] && [[ -d "$script_dir/.git" ]]; then
+        local resolved_script resolved_install
+        resolved_script="$(cd "$script_dir" && pwd -P)"
+        resolved_install="$(cd "$INSTALL_DIR" 2>/dev/null && pwd -P 2>/dev/null || echo "")"
+
+        if [[ "$resolved_script" != "$resolved_install" ]]; then
+            if [[ -L "$INSTALL_DIR" ]]; then
+                rm "$INSTALL_DIR"
+            elif [[ -d "$INSTALL_DIR" ]]; then
+                warn "$INSTALL_DIR already exists. Backing up to ${INSTALL_DIR}.bak"
+                mv "$INSTALL_DIR" "${INSTALL_DIR}.bak"
+            fi
+            ln -s "$script_dir" "$INSTALL_DIR"
+            info "Linked $INSTALL_DIR -> $script_dir"
+        fi
+    elif [[ -d "$INSTALL_DIR/.git" ]] || { [[ -L "$INSTALL_DIR" ]] && [[ -d "$(readlink -f "$INSTALL_DIR" 2>/dev/null)/.git" ]]; }; then
+        info "Updating oss-helper repository..."
+        git -C "$INSTALL_DIR" pull --quiet
     else
-        echo ""
+        info "Cloning oss-helper repository to $INSTALL_DIR..."
+        git clone --depth 1 "$REPO_URL" "$INSTALL_DIR"
     fi
 }
 
-# Download or copy a file
+# Ensure the known-projects repository is available
+ensure_known_projects_repo() {
+    if [[ -d "$KNOWN_PROJECTS_DIR/.git" ]]; then
+        info "Updating known-projects repository..."
+        git -C "$KNOWN_PROJECTS_DIR" pull --quiet
+    else
+        info "Cloning known-projects repository to $KNOWN_PROJECTS_DIR..."
+        git clone --depth 1 --branch "$KNOWN_PROJECTS_BRANCH" "$KNOWN_PROJECTS_REPO_URL" "$KNOWN_PROJECTS_DIR"
+    fi
+}
+
+# Copy a file from the install directory
 fetch_file() {
     local src="$1"
     local dest="$2"
-    local script_dir
-    script_dir="$(get_script_dir)"
 
-    # If running locally and file exists, copy it
-    if [[ -n "$script_dir" ]] && [[ -f "$script_dir/$src" ]]; then
-        cp "$script_dir/$src" "$dest"
+    if [[ -f "$INSTALL_DIR/$src" ]]; then
+        cp "$INSTALL_DIR/$src" "$dest"
         return 0
     fi
 
-    # Otherwise, download from remote
+    # Fallback: download from remote
     if command -v curl &> /dev/null; then
         curl -fsSL "$BASE_URL/$src" -o "$dest"
     elif command -v wget &> /dev/null; then
         wget -q "$BASE_URL/$src" -O "$dest"
     else
-        error "Neither curl nor wget found. Cannot download files."
+        error "Source file not found: $INSTALL_DIR/$src and no download tool available."
         return 1
     fi
+}
+
+# Create a symlink to a file in the install directory
+link_file() {
+    local src="$1"
+    local dest="$2"
+    local abs_install_dir
+    abs_install_dir="$(cd "$INSTALL_DIR" && pwd -P)"
+
+    if [[ -f "$abs_install_dir/$src" ]]; then
+        ln -sf "$abs_install_dir/$src" "$dest"
+        return 0
+    fi
+
+    error "Source file not found: $abs_install_dir/$src"
+    return 1
+}
+
+# Create a symlink to a directory
+link_dir() {
+    local src_dir="$1"
+    local dest="$2"
+
+    if [[ -d "$src_dir" ]]; then
+        if [[ -L "$dest" ]] || [[ -e "$dest" ]]; then
+            rm -rf "$dest"
+        fi
+        ln -s "$src_dir" "$dest"
+        return 0
+    fi
+
+    error "Source directory not found: $src_dir"
+    return 1
+}
+
+# Install project rules from the known-projects clone
+install_rules() {
+    local rules_dir="$1"
+    local use_symlinks="${2:-false}"
+
+    if [[ ! -d "$KNOWN_PROJECTS_DIR" ]]; then
+        warn "Known-projects repository not available, skipping rules installation."
+        info "  Rules directory: $rules_dir (project rules can be installed on demand)"
+        return 0
+    fi
+
+    info "  Installing project rules..."
+    local abs_kp_dir
+    abs_kp_dir="$(cd "$KNOWN_PROJECTS_DIR" && pwd -P)"
+
+    for project_dir in "$abs_kp_dir"/*/; do
+        [[ -f "$project_dir/project-info.md" ]] || continue
+        local project
+        project="$(basename "$project_dir")"
+
+        if [[ "$use_symlinks" == "true" ]]; then
+            if link_dir "$project_dir" "$rules_dir/$project"; then
+                info "    Linked: $project/"
+            else
+                error "    Failed to link: $project/"
+                return 1
+            fi
+        else
+            mkdir -p "$rules_dir/$project"
+            for rule_file in project-info.md project-standards.md project-guidelines.md project-security.md; do
+                if [[ -f "$project_dir/$rule_file" ]]; then
+                    cp "$project_dir/$rule_file" "$rules_dir/$project/$rule_file"
+                fi
+            done
+            info "    Installed: $project/"
+        fi
+    done
 }
 
 # Convert a guideline file to Gemini CLI .toml format
@@ -444,7 +553,7 @@ install_skill_agent() {
         fi
     done
 
-    # Install each skill
+    # Install each skill (symlinks for instant updates)
     for skill_dir in "${SKILL_DIRS[@]}"; do
         local target_dir="$skills_root/$skill_dir"
 
@@ -455,26 +564,26 @@ install_skill_agent() {
 
         info "  Installing skill: $skill_dir"
 
-        # Install skill files
+        # Install skill files as symlinks
         for file in ${SKILL_FILES[$skill_dir]}; do
             local filename
             filename="$(basename "$file")"
             local dest="$target_dir/$filename"
 
-            if fetch_file "$file" "$dest"; then
-                info "    Installed: $filename"
+            if link_file "$file" "$dest"; then
+                info "    Linked: $filename"
             else
-                error "    Failed to install: $filename"
+                error "    Failed to link: $filename"
                 return 1
             fi
         done
 
-        # Copy shared init.md into each skill directory
+        # Symlink shared init.md into each skill directory
         local init_dest="$target_dir/init.md"
-        if fetch_file "$SHARED_INIT" "$init_dest"; then
-            info "    Installed: init.md (shared)"
+        if link_file "$SHARED_INIT" "$init_dest"; then
+            info "    Linked: init.md (shared)"
         else
-            error "    Failed to install: init.md"
+            error "    Failed to link: init.md"
             return 1
         fi
     done
@@ -522,10 +631,13 @@ install_skill_agent() {
         rm -f "$rules_dir/$old_file"
     done
 
-    info "  Skills installed to: $skills_root/{${SKILL_DIRS[*]}}"
+    # Install project rules (symlinks)
+    install_rules "$rules_dir" "true"
+
+    info "  Skills linked to: $skills_root/{${SKILL_DIRS[*]}} (symlinks -> $INSTALL_DIR)"
     info "  Commands installed to: $commands_dir"
     info "  Sub-agents installed to: $agents_dir"
-    info "  Rules directory: $rules_dir (project rules installed on demand)"
+    info "  Rules linked to: $rules_dir (symlinks -> $KNOWN_PROJECTS_DIR)"
 }
 
 # Install for Gemini CLI (individual TOML commands)
@@ -607,9 +719,12 @@ install_gemini() {
         fi
     done
 
+    # Install project rules (copies)
+    install_rules "$rules_dir" "false"
+
     info "  Commands installed to: $commands_dir"
     info "  Sub-agents installed to: $agents_dir"
-    info "  Rules directory: $rules_dir (project rules installed on demand)"
+    info "  Rules installed to: $rules_dir"
 }
 
 # Install for OpenCode (individual commands with frontmatter)
@@ -689,9 +804,12 @@ install_opencode() {
         fi
     done
 
+    # Install project rules (copies)
+    install_rules "$rules_dir" "false"
+
     info "  Commands installed to: $commands_dir"
     info "  Sub-agents installed to: $agents_dir"
-    info "  Rules directory: $rules_dir (project rules installed on demand)"
+    info "  Rules installed to: $rules_dir"
 }
 
 # Install for Codex (skill directories under ~/.agents/skills/)
@@ -776,9 +894,12 @@ install_codex() {
         fi
     done
 
+    # Install project rules (copies)
+    install_rules "$codex_rules_dir" "false"
+
     info "  Skills installed to: $skills_root/{${SKILL_DIRS[*]}}"
     info "  Sub-agents installed to: $agents_dir"
-    info "  Rules directory: $codex_rules_dir (project rules installed on demand)"
+    info "  Rules installed to: $codex_rules_dir"
 }
 
 # Install for a specific agent
@@ -829,6 +950,11 @@ main() {
     echo ""
     echo "AI Agent OSS Helper - Installer"
     echo "================================"
+    echo ""
+
+    # Ensure both repositories are available
+    ensure_repo
+    ensure_known_projects_repo
     echo ""
 
     for agent in "${agents_to_install[@]}"; do

--- a/skills/_shared/init.md
+++ b/skills/_shared/init.md
@@ -242,3 +242,41 @@ If the remote version differs from the local version (or the local version is un
    - Re-read the updated rule files before continuing
 
 4. If the user declines, continue with the existing local rules.
+
+## 4. OSS Helper Version Check
+
+Check if newer OSS Helper skills are available from the remote repository.
+
+### 4.1 Check local repository
+
+Verify the OSS Helper repository exists locally:
+
+```bash
+test -d ~/.oss-helper/.git 2>/dev/null || test -d "$(readlink -f ~/.oss-helper 2>/dev/null)/.git" 2>/dev/null
+```
+
+If neither condition is true, skip this check entirely.
+
+### 4.2 Throttle check
+
+Only perform the remote check if the last check was more than 24 hours ago:
+
+```bash
+find ~/.oss-helper -maxdepth 1 -name ".last-update-check" -mtime -1 2>/dev/null | head -1
+```
+
+If the above command produces output (file exists and was modified within the last 24 hours), skip the rest of this step.
+
+### 4.3 Fetch and compare
+
+```bash
+git -C ~/.oss-helper fetch --quiet 2>/dev/null
+UPDATES="$(git -C ~/.oss-helper log HEAD..origin/main --oneline 2>/dev/null)"
+touch ~/.oss-helper/.last-update-check
+```
+
+If `$UPDATES` is non-empty, briefly inform the user:
+
+> **OSS Helper update available.** Follow the Self-Update guideline to update.
+
+Do NOT block or halt execution for this notification. Continue with the requested task immediately after displaying the message.

--- a/skills/oss-project/SKILL.md
+++ b/skills/oss-project/SKILL.md
@@ -27,3 +27,4 @@ After initialization, read and follow the appropriate guideline file based on th
 | Update project rule files | `update-knowledge.md` |
 | Initialize or rediscover a multi-repo workspace | `oss-workspace-init.md` |
 | Report status of all repos in a workspace | `oss-workspace-status.md` |
+| Update the OSS Helper itself | `self-update.md` |

--- a/skills/oss-project/install-info.md
+++ b/skills/oss-project/install-info.md
@@ -1,13 +1,25 @@
-### 1. Resolve Known-Projects Repository
+### 1. Resolve Known-Projects Source
 
-Use the following values (override via environment if set):
+First, check if a local clone of the known-projects repository exists:
+
+```bash
+test -d ~/.oss-helper/known-projects/.git 2>/dev/null
+```
+
+If the local clone exists, use it as the source for all operations in this guideline. Read files directly from `~/.oss-helper/known-projects/<project>/` instead of making GitHub API calls. To get the latest version, pull first:
+
+```bash
+git -C ~/.oss-helper/known-projects pull --quiet 2>/dev/null
+```
+
+If the local clone does not exist, fall back to the GitHub API using these values (override via environment if set):
 
 | Variable | Default |
 |----------|---------|
 | `OSS_KNOWN_PROJECTS_REPO` | `Open-Harness-Engineering/ai-agents-oss-known-projects` |
 | `OSS_KNOWN_PROJECTS_BRANCH` | `main` |
 
-These determine the GitHub repo and branch that the command reads project rule files from.
+These determine the GitHub repo and branch that the guideline reads project rule files from.
 
 ### 2. Resolve Target Rules Directory
 

--- a/skills/oss-project/self-update.md
+++ b/skills/oss-project/self-update.md
@@ -1,0 +1,91 @@
+# Self-Update
+
+Update the OSS Helper skills and project rules to the latest version.
+
+## Instructions
+
+### 1. Locate Repository
+
+Find the OSS Helper repository:
+
+```bash
+test -d ~/.oss-helper/.git 2>/dev/null || test -d "$(readlink -f ~/.oss-helper 2>/dev/null)/.git" 2>/dev/null
+```
+
+If `~/.oss-helper` does not exist or is not a git repository, inform the user and stop:
+
+> OSS Helper was not installed via git. Please reinstall:
+> ```
+> git clone https://github.com/Open-Harness-Engineering/ai-agents-oss-helper.git ~/.oss-helper
+> ~/.oss-helper/install.sh
+> ```
+
+### 2. Update OSS Helper
+
+Fetch and show available updates:
+
+```bash
+git -C ~/.oss-helper fetch --quiet 2>/dev/null
+git -C ~/.oss-helper log HEAD..origin/main --oneline
+```
+
+If no output, report "OSS Helper skills are already up to date."
+
+Otherwise, show the list of incoming changes and pull:
+
+```bash
+git -C ~/.oss-helper pull --quiet
+```
+
+### 3. Update Known-Projects
+
+If `~/.oss-helper/known-projects/.git` exists, update it too:
+
+```bash
+git -C ~/.oss-helper/known-projects fetch --quiet 2>/dev/null
+git -C ~/.oss-helper/known-projects log HEAD..origin/main --oneline
+```
+
+If updates are available, pull:
+
+```bash
+git -C ~/.oss-helper/known-projects pull --quiet
+```
+
+If the directory does not exist, skip this step.
+
+### 4. Re-install for Conversion Agents
+
+For agents that use symlinks (Claude, Bob), no further action is needed — the symlinks already point to the updated files.
+
+For agents that require format conversion (Gemini, OpenCode, Codex), re-run the install script:
+
+```bash
+~/.oss-helper/install.sh <agent>
+```
+
+Detect the current agent and only re-install for conversion agents. For Claude and Bob, skip this step.
+
+### 5. Reset Update Check
+
+Reset the update check throttle:
+
+```bash
+touch ~/.oss-helper/.last-update-check
+```
+
+### 6. Report Results
+
+Show the user what was updated:
+
+```bash
+git -C ~/.oss-helper log --oneline -10
+```
+
+If known-projects was also updated:
+
+```bash
+git -C ~/.oss-helper/known-projects log --oneline -10
+```
+
+> OSS Helper updated successfully.


### PR DESCRIPTION
## Summary

- `install.sh` now clones both the oss-helper repo (skills) and the known-projects repo (rules) to `~/.oss-helper/`
- For Claude/Bob: skill files and rule directories are **symlinked** — `git pull` updates everything instantly
- For Gemini/OpenCode/Codex: files are copied (format conversion required) — re-run `install.sh <agent>` after pulling
- Adds a **self-update** guideline (`skills/oss-project/self-update.md`) and a **24-hour throttled version check** in the shared `init.md`
- `install-info.md` now prefers the local known-projects clone over GitHub API calls

## Design

This implements **option 4** from #25: clone both repos independently rather than using submodules or merging them back together. This preserves the architectural separation from #40 (rules in a separate repo) while giving users a single `git pull` update experience.

```
~/.oss-helper/                          # git clone of ai-agents-oss-helper
├── skills/
│   ├── _shared/init.md                 # shared initialization (version check added here)
│   ├── oss-issues/                     # issue management skill
│   ├── oss-review/                     # PR management skill
│   ├── oss-ci/                         # CI/CD skill
│   ├── oss-security/                   # security skill
│   ├── oss-project/                    # project setup skill (includes self-update.md)
│   └── oss-qe/                         # quality engineering skill
├── install.sh
├── known-projects/                     # git clone of ai-agents-oss-known-projects
│   ├── camel-core/
│   ├── wanaku/
│   └── ...
└── .gitignore                          # excludes known-projects/ and .last-update-check

~/.claude/skills/oss-issues/            # symlinks -> ~/.oss-helper/skills/oss-issues/*
~/.claude/skills/oss-review/            # symlinks -> ~/.oss-helper/skills/oss-review/*
~/.claude/skills/oss-ci/                # ...
~/.claude/skills/oss-security/          # ...
~/.claude/skills/oss-project/           # ...
~/.claude/skills/oss-qe/               # ...
~/.claude/rules/camel-core/             # symlinks -> ~/.oss-helper/known-projects/camel-core/
```

Supersedes #25.

## Test plan

- [x] `~/.oss-helper/install.sh claude` — skill files are symlinks into oss-helper clone
- [x] `~/.oss-helper/install.sh claude` — rule directories are symlinks into known-projects clone
- [x] Modifying a rule in `~/.oss-helper/known-projects/` instantly visible through the symlink in `~/.claude/rules/`
- [x] `bash -n install.sh` — no syntax errors
- [x] `/oss-self-update` works in a Claude session
- [x] Version check throttle works (skips if < 24h old)

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)