### PR TITLE
feat: support optional project-security.md rule file

### DIFF
--- a/commands/.oss-init.md
+++ b/commands/.oss-init.md
@@ -28,6 +28,8 @@ git rev-parse --show-toplevel
 
 Check for project rules in the following order. Use the **first source found**:
 
+> Three rule files are always expected: `project-info.md`, `project-standards.md`, and `project-guidelines.md`. A fourth file, `project-security.md`, is **optional** — load it when present (it is consumed only by the security commands) and do not treat its absence as an error.
+
 #### A. Project-local rules (`.oss-ai-helper-rules/`)
 
 Check if `.oss-ai-helper-rules/` exists in the repository root:
@@ -40,6 +42,7 @@ If the directory exists, read the project's rule files directly from it:
 - `<repo-root>/.oss-ai-helper-rules/project-info.md` - Repository metadata, issue tracker, related repos
 - `<repo-root>/.oss-ai-helper-rules/project-standards.md` - Build tools, commands, code style
 - `<repo-root>/.oss-ai-helper-rules/project-guidelines.md` - Branching, commits, PR policies
+- `<repo-root>/.oss-ai-helper-rules/project-security.md` - (optional) Security/CVE-handling & publishing workflow — read it only if the file exists
 
 These project-local rules take precedence over installed rules. Proceed to **step 3** (Version Check).
 
@@ -60,6 +63,7 @@ Iterate over the subdirectories of that rules directory and read each `<project>
 - `<project>/project-info.md` - Repository metadata, issue tracker, related repos
 - `<project>/project-standards.md` - Build tools, commands, code style
 - `<project>/project-guidelines.md` - Branching, commits, PR policies
+- `<project>/project-security.md` - (optional) Security/CVE-handling & publishing workflow — read it only if the file exists
 
 Proceed to **step 3** (Version Check).
 
@@ -186,6 +190,8 @@ Create with:
 - `## Version` section with the current git SHA of the project being configured
 
 Use any project in the [`ai-agents-oss-known-projects`](https://github.com/Open-Harness-Engineering/ai-agents-oss-known-projects) repository as a template for the exact format.
+
+Do **not** auto-generate `project-security.md` — the security/CVE workflow cannot be reliably inferred from source. Leave it out; a maintainer can add it later (use any `camel-*` project in the known-projects repository as a reference).
 
 After creating the files, inform the user:
 

--- a/commands/oss-add-project.md
+++ b/commands/oss-add-project.md
@@ -115,6 +115,29 @@ Create with:
 
 Use any existing project directory in the [`ai-agents-oss-known-projects`](https://github.com/Open-Harness-Engineering/ai-agents-oss-known-projects) repository (e.g., `wanaku/`) as a template for the exact format.
 
+#### D. `project-security.md` (optional)
+
+Create this file **only** if the project has a defined security / CVE-handling workflow worth recording (most relevant for projects that publish CVE advisories, such as ASF projects). Do **not** fabricate a workflow: if the user has not described one and you cannot determine it from the project's security policy (`SECURITY.md`, an `https://www.apache.org/security/`-style page, etc.), skip this file and tell the user it can be added later.
+
+When you do create it, include:
+- H1 heading: `# Project Security`
+- Intro paragraph (note that the file is optional and consumed only by the security commands: `/oss-triage-security-report`, `/oss-create-security-advisory`, `/oss-draft-cve`, `/oss-analyze-third-party-cve`)
+- Private reporting channel
+- GitHub private vulnerability reporting (used / not used)
+- CVE Numbering Authority (CNA)
+- Severity scheme
+- Advisory source format and section structure
+- Advisory template (reference)
+- Publication location
+- Signing key
+- Supported release lines / backport branches
+- Disclosure & announcement steps
+- Third-party CVE "not affected" notes location
+- A short `## CVE Handling Workflow` section
+- `## Version` section with the current git SHA of the project being configured
+
+Use any `camel-*` project directory in the known-projects repository as a template for the exact format.
+
 ### 5. Publish the Rules
 
 **If rules were created in `.oss-ai-helper-rules/` (project-local):** The rules travel with the repository and do not need any other publication step. Inform the user:
@@ -138,7 +161,7 @@ Inform the user:
 You MUST:
 - Follow the existing format of each rule file exactly (use other project directories as templates)
 - Confirm all details with the user before making changes
-- Create all three rule files in the new subdirectory
+- Create all three required rule files in the new subdirectory; create the optional `project-security.md` only when a real security/CVE workflow is known (never invent one)
 
 You MUST NOT:
 - Create per-project command files (all commands are generic)

--- a/commands/oss-analyze-third-party-cve.md
+++ b/commands/oss-analyze-third-party-cve.md
@@ -18,7 +18,9 @@ This command is the dependency-side counterpart of `/oss-triage-security-report`
 
 ### 1. Initialize Project Context
 
-**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines, and `project-security.md` when present) is loaded.
+
+If `project-security.md` names a location for third-party **"not affected" notes**, use it when proposing where to record the analysis (step 8).
 
 ### 2. Establish Boundaries
 
@@ -228,7 +230,7 @@ Based on the verdict, offer one or more of the following actions. Do NOT execute
 
 **If not exposed in current usage:**
 
-4. **Document the rationale** - propose a short, sanitized note for the project's security notes or a private tracking issue. Do NOT publish exploit specifics. The note should describe *why* the project's usage does not reach the vulnerable path, so future contributors do not re-derive the analysis.
+4. **Document the rationale** - propose a short, sanitized note for the project's security notes or a private tracking issue. If `project-security.md` names a location for third-party **"not affected" notes**, propose recording it there. Do NOT publish exploit specifics. The note should describe *why* the project's usage does not reach the vulnerable path, so future contributors do not re-derive the analysis.
 
 **If not affected:**
 

--- a/commands/oss-create-security-advisory.md
+++ b/commands/oss-create-security-advisory.md
@@ -15,9 +15,13 @@ Privately report a security vulnerability to a GitHub repository using GitHub's 
 
 ### 1. Initialize Project Context
 
-**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines, and `project-security.md` when present) is loaded.
+
+If `project-security.md` declares a **Private reporting channel** that is not GitHub private vulnerability reporting (for example an ASF `security@apache.org` list), prefer guiding the reporter to that channel over the GitHub `/reports` flow — see step 2.
 
 ### 2. Verify Eligibility
+
+**First, check `project-security.md` (if present).** If it declares a **Private reporting channel** other than GitHub private vulnerability reporting (for example an ASF `security@apache.org` mailing list), do **not** use the GitHub `/reports` flow. Instead, give the user the exact reporting address from that file, draft a private report email body (reuse the Markdown structure from step 5), and remind them of responsible-disclosure expectations. Only continue with the GitHub flow below if no security file exists, the file points to GitHub PVR, or the user explicitly asks for the GitHub path.
 
 Read the **Issue tracker** field from the project's `project-info.md`:
 - If the issue tracker is **not** `GitHub`, stop and tell the user: "Private vulnerability reporting is a GitHub-specific feature. This project uses a different issue tracker."

--- a/commands/oss-draft-cve.md
+++ b/commands/oss-draft-cve.md
@@ -12,7 +12,7 @@ This command is drafting-only: it produces the advisory files locally for the ma
 
 **Arguments:**
 - `<cve_id>` - The **reserved** CVE ID (e.g. `CVE-2026-25747`). Required. The command does not reserve IDs — it only drafts against one already issued by the CNA.
-- `template=<url_or_path>` - Required. URL to a reference advisory (e.g. `https://camel.apache.org/security/CVE-2026-25747.html`) **or** a local file (`.md` / `.pdf` / `.html`) whose layout the draft should match.
+- `template=<url_or_path>` - URL to a reference advisory (e.g. `https://camel.apache.org/security/CVE-2025-27636.html`) **or** a local file (`.md` / `.pdf` / `.html`) whose layout the draft should match. Required **unless** `project-security.md` provides an *Advisory template (reference)*, which is then used by default.
 - `triage_ref=<path_or_url>` - Optional. Path or URL to the output of `/oss-triage-security-report`. Used to auto-populate description, affected code paths, and severity.
 - `fix_pr=<pr_or_url>` - Optional. PR number or URL containing the fix. Used to extract fixed-version ranges, commit hashes, and issue references.
 
@@ -20,7 +20,9 @@ This command is drafting-only: it produces the advisory files locally for the ma
 
 ### 1. Initialize Project Context
 
-**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines, and `project-security.md` when present) is loaded.
+
+If `project-security.md` is present, treat its fields as defaults for this command: **Advisory template (reference)** seeds `template=` (steps 2 and 4); **Advisory section structure** seeds the skeleton (step 5); **Advisory source format** sets the output extension (step 7); **Supported release lines** inform the version mapping (step 6.2); **Publication location** and **Signing key** feed the review checklist (step 8). When the file is absent, gather these interactively as described below.
 
 ### 2. Parse Input
 
@@ -31,7 +33,7 @@ Parse the argument string into four values:
 - `triage_ref` - optional key/value
 - `fix_pr` - optional key/value
 
-If `cve_id` or `template` is missing, stop and print the usage block above.
+If `cve_id` is missing, stop and print the usage block above. If `template` is missing, fall back to the **Advisory template (reference)** declared in `project-security.md`; only stop and print the usage block if neither a `template=` argument nor a security-file reference is available.
 
 ### 3. Validate the Reserved CVE ID
 

--- a/commands/oss-install-info.md
+++ b/commands/oss-install-info.md
@@ -174,6 +174,14 @@ If `gh` is not available, fall back to `curl`:
 curl -fsSL "https://raw.githubusercontent.com/<OSS_KNOWN_PROJECTS_REPO>/<OSS_KNOWN_PROJECTS_BRANCH>/<project>/<file>" -o <RULES_DIR>/<project>/<file>
 ```
 
+Then handle the **optional** `project-security.md`. First check whether the project ships it:
+
+```bash
+gh api "repos/<OSS_KNOWN_PROJECTS_REPO>/contents/<project>/project-security.md?ref=<OSS_KNOWN_PROJECTS_BRANCH>" --jq '.name' 2>/dev/null
+```
+
+If that returns `project-security.md`, fetch it the same way as the required files. If it returns nothing, the project has no security rules — skip it; its absence is expected and must not fail the install.
+
 #### 6.4 Confirm the install
 
 Report to the user:
@@ -185,14 +193,16 @@ Installed rules for <project> to <RULES_DIR>/<project>/:
 - project-guidelines.md
 ```
 
+If `project-security.md` was present and fetched, list it too.
+
 Suggest the next step:
 > The next time you run an OSS Helper command from a project whose git remote matches `<remote-pattern>`, these rules will be loaded automatically.
 
 ### 7. Constraints
 
 You MUST:
-- Make minimal API calls — per project: one to validate, three to fetch the rule files, plus one extra to compare versions if a local copy already exists
-- Install only the three rule files (`project-info.md`, `project-standards.md`, `project-guidelines.md`)
+- Make minimal API calls — per project: one to validate, three to fetch the required rule files, one to check for the optional `project-security.md` (and one more to fetch it when present), plus one extra to compare versions if a local copy already exists
+- Install the three required rule files (`project-info.md`, `project-standards.md`, `project-guidelines.md`), plus the optional `project-security.md` when the project provides it
 - Ask the user before overwriting a local copy that has a different `## Version` SHA; in `all` mode, reuse the first answer for the rest of the run
 - Create each target rules directory if it does not exist
 
@@ -206,7 +216,7 @@ You MUST NOT:
 
 ### 8. Acceptance Criteria
 
-- The three rule files for each requested `<project>` are present in `<RULES_DIR>/<project>/` after the command completes successfully
+- The three required rule files for each requested `<project>` are present in `<RULES_DIR>/<project>/` after the command completes successfully, plus `project-security.md` when the project provides it
 - The local `## Version` SHA matches the remote SHA for each installed project
 - Subsequent OSS Helper commands load the newly installed rules through `.oss-init.md` step 2B
 - Existing project-local `.oss-ai-helper-rules/` directories continue to take precedence

--- a/commands/oss-triage-security-report.md
+++ b/commands/oss-triage-security-report.md
@@ -17,7 +17,9 @@ This command does NOT publish any security details to public trackers. It is a l
 
 ### 1. Initialize Project Context
 
-**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines, and `project-security.md` when present) is loaded.
+
+If `project-security.md` is present, use its **Private reporting channel** verbatim in the follow-up step (step 7) instead of guessing an address.
 
 ### 2. Acquire the Report
 
@@ -151,7 +153,7 @@ Based on the recommendation, offer the user one or more of the following actions
 **If valid and not public:**
 
 1. **Submit a private advisory** (GitHub projects) - hand off to `/oss-create-security-advisory` with the full technical detail. This is the preferred path when private vulnerability reporting is available.
-2. **Contact the project's security team directly** (ASF projects) - provide the user with the appropriate `security@<project>.apache.org` or `private@<project>.apache.org` address and a draft email body.
+2. **Contact the project's security team directly** (ASF projects) - use the **Private reporting channel** from `project-security.md` if present (do **not** guess the address); otherwise provide the appropriate `security@<project>.apache.org` or `private@<project>.apache.org` address. Include a draft email body.
 
 **If valid and already public, or safe to track as hardening:**
 


### PR DESCRIPTION
## Summary

- `.oss-init.md` now loads an **optional** 4th rule file, `project-security.md`, when present. Backward-compatible: absence is not an error and existing 3-file installs work unchanged.
- The four security commands consume it:
  - `oss-draft-cve` — defaults `template=` from the **Advisory template (reference)** field; `template=` is no longer required when the security file is present.
  - `oss-create-security-advisory` & `oss-triage-security-report` — use the **Private reporting channel** verbatim instead of guessing (e.g. `security@<project>.apache.org`) or forcing the GitHub `/reports` flow. For ASF Camel that means directing reporters to `security@apache.org`.
  - `oss-analyze-third-party-cve` — uses the **"not affected" notes** location when proposing where to record an exposure analysis.
- `oss-install-info` fetches `project-security.md` when the project provides it (silent skip when absent).
- `oss-add-project` documents it as optional and explicitly will **not** auto-generate or fabricate a security workflow.

Pairs with `Open-Harness-Engineering/ai-agents-oss-known-projects#4`, which ships the workflow playbook (`workflows/cve-workflow.md`) and the per-project `project-security.md` config for the five Apache Camel projects.

## Test plan

- [ ] In a project with no `project-security.md`, run `/oss-draft-cve` and confirm it still requires `template=` (existing behavior).
- [ ] In a Camel checkout with `project-security.md` installed, run `/oss-draft-cve CVE-XXXX-XXXXX` without `template=` and confirm it picks up the reference advisory automatically.
- [ ] In a Camel checkout, run `/oss-create-security-advisory` and confirm it points to `security@apache.org` instead of attempting the GitHub `/reports` flow.
- [ ] Run `/oss-add-project` for a hypothetical new project and confirm it does **not** create a `project-security.md` unless a real workflow is described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)