### PR TITLE
feat: add /oss-qe-create-test-plan and /oss-qe-verify commands

### DIFF
--- a/commands/oss-qe-create-test-plan.md
+++ b/commands/oss-qe-create-test-plan.md
@@ -1,0 +1,203 @@
+# QE Create Test Plan
+
+Create a test plan for a project feature, component, or workflow. Test plans are Markdown documents designed for execution by both humans and AI agents — they use numbered phases, environment variables with defaults, PASS/FAIL assertions on every step, and a test summary matrix at the end.
+
+This command is **planning only**. It analyzes the project and produces a test plan document. To execute a plan, use `/oss-qe-verify`. To fix a bug found during execution, use `/oss-fix-issue`.
+
+## Usage
+
+```
+/oss-qe-create-test-plan <test-plan-name> [additional instructions]
+```
+
+**Arguments:**
+- `<test-plan-name>` - Short name for the test plan (e.g., `operator-basic-tests`, `smoke-tests`, `cli-commands`)
+- `[additional instructions]` - Optional guidance: what to test, scope, target environment, specific concerns
+
+**Examples:**
+```
+/oss-qe-create-test-plan operator-basic-tests Create a test plan for testing the Kubernetes operator lifecycle
+/oss-qe-create-test-plan smoke-tests
+/oss-qe-create-test-plan cli-commands Test all CLI subcommands including negative cases
+```
+
+## Instructions
+
+### 1. Initialize Project Context
+
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
+
+### 2. Parse Input
+
+Extract from the arguments:
+- **Test plan name** — the short identifier (e.g., `operator-basic-tests`). This becomes the filename: `<name>.md`.
+- **Additional instructions** — optional scope, environment, or focus guidance from the user.
+
+### 3. Agent Delegation
+
+If a **qa-test-strategist**, **QE**, **QA**, or **tester** agent is available, delegate the plan creation to it. The specialized agent should receive:
+- The project context (project-info, project-standards, project-guidelines)
+- The test plan name and any additional instructions
+- The test plan format reference (step 7)
+- Any existing common steps found in step 6
+
+**MUST NOT** delegate to coding agents (backend-specialist, frontend-specialist, java-test-engineer, etc.) unless the user explicitly instructs otherwise. Coding agents optimize for implementation, not test strategy — they produce scripts, not verifiable test plans.
+
+If no QE/QA agent is available, the main agent creates the plan directly.
+
+### 4. Search for Existing Test Plans
+
+Before creating a new plan, check if one already exists. Search in this order:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+
+# Search order
+ls "${REPO_ROOT}/tests/plans/<name>.md" 2>/dev/null
+ls "${REPO_ROOT}/test-plans/<name>.md" 2>/dev/null
+ls "${REPO_ROOT}/.oss-ai-helper-rules/test-plans/<name>.md" 2>/dev/null
+```
+
+If a plan with this name is found:
+- Present it to the user (overview, phase count, test count)
+- Ask: **update the existing plan** or **create a fresh one**?
+- If updating, read the existing plan fully and modify in place
+- If creating fresh, proceed to step 5
+
+### 5. Analyze the Project
+
+Gather information to inform the test plan:
+
+- **Project structure** — modules, entry points, APIs, CRDs, CLI commands, UI pages
+- **Build and test tools** — from `project-standards.md` (build command, test command, required tools)
+- **Existing tests** — scan for test directories, test frameworks, existing test suites
+- **Risk areas** — recent changes (`git log --oneline -20`), complex modules, security-sensitive code
+- **Existing documentation** — README, CONTRIBUTING, API docs, architecture docs
+- **User instructions** — scope and focus from the additional instructions argument
+
+### 6. Search for Reusable Common Steps
+
+Check if the project already has reusable test procedures:
+
+```bash
+ls "${REPO_ROOT}/tests/plans/common/" 2>/dev/null
+```
+
+If common steps exist, read them. Reference them in the new plan instead of duplicating their content. If a procedure in the new plan would be useful across multiple plans (e.g., namespace setup, login, cleanup), extract it into a new common doc.
+
+### 7. Generate the Test Plan
+
+Produce a test plan following the format established by the project's existing plans. The plan must be executable by both humans following it step-by-step and AI agents running the commands.
+
+#### Test Plan Structure
+
+The generated plan MUST follow this structure. Use the sample plans in `sample-plans/plans/` (e.g., `operator-basic-functionality.md`, `mcp-cli-commands.md`, `basic-ui-test.md`) as format references.
+
+**Required sections, in order:**
+
+1. **H1 title** — `# Test Plan: <descriptive title>`
+2. **Overview** — 1-3 sentences: what this plan tests and why. State whether every step is automatable or if any manual steps exist.
+3. **Prerequisites** — three subsections:
+   - **Required tools** — a table with columns: Tool, Minimum version, Verify command
+   - **Prerequisite check script** — a shell script that checks all tools are installed and prints PASS/FAIL for each
+   - **Environment variables** — shell export statements with defaults using `${VAR:-default}` syntax, followed by a table (Variable, Default, Description)
+4. **Helper functions** (if needed) — reusable shell functions like `wait_for_deletion`, `get_token`, etc. Reference common docs when they exist.
+5. **Phases** — numbered sequentially starting from 0:
+   - Phase 0: Setup / prerequisites (login, namespace, dependencies)
+   - Phase 1-N: Test scenarios (grouped by feature/area)
+   - Final phase: Cleanup (idempotent teardown)
+6. **Test Summary Matrix** — a table with columns: Phase, Test ID, Test Name, Priority
+
+#### Format Rules
+
+These rules encode the project's test plan conventions (from the contributing guide):
+
+1. **Phases, not scripts** — organize tests into numbered phases that run sequentially. Each phase groups related assertions. This makes it easy to skip phases, resume after failure, or run a subset.
+
+2. **Every step must be verifiable** — each step needs: a command, an expected outcome, and a PASS/FAIL assertion. Avoid steps that only run a command without checking the result.
+
+3. **Prefer polling over sleeping** — use `oc wait`, `oc rollout status`, health check loops, or polling instead of fixed `sleep` calls. Clusters and environments vary in speed.
+
+4. **Parameterize everything configurable** — images, versions, hosts, IPs, ports, namespaces, branch names, labels go into environment variables with sensible defaults. Never hard-code:
+   - Image tags → `export MY_IMAGE="${MY_IMAGE:-quay.io/org/component:latest}"`
+   - Cluster URLs → `export CLUSTER_URL="${CLUSTER_URL:-http://localhost:8080}"`
+   - Namespaces → `export NAMESPACE="${NAMESPACE:-test-ns}"`
+
+5. **Extract reusable steps** — if a procedure appears in more than one plan (or is likely to), move it to `tests/plans/common/`. Reference it with a link and note which variables must be set before and after.
+
+6. **Keep the main plan lean** — only logic unique to this test scenario belongs in the main plan. Replace duplicated procedures with references to common docs.
+
+7. **Include negative tests** — verify that invalid inputs are rejected gracefully: missing required fields, references to non-existent resources, malformed data.
+
+8. **Cleanup must be idempotent** — use `--ignore-not-found=true` on delete commands and `2>/dev/null || true` on wait commands. A cleanup phase that fails on missing resources makes re-runs painful.
+
+9. **Shell compatibility** — use POSIX-compatible constructs. Avoid bash-only features like `${!VAR}` (indirect expansion). If bash is required, wrap the block in `bash -c '...'`.
+
+10. **End with a test summary matrix** — every plan must include a summary table listing all phases, test IDs, test names, and priorities.
+
+### 8. Credential and Infrastructure Safety
+
+Before writing the plan, verify:
+
+- **No hardcoded credentials** — passwords, tokens, secrets, API keys go into environment variables. Default values must be placeholders (e.g., `<your-token>`) or generic safe defaults (e.g., `admin` for local dev only).
+- **No internal infrastructure** — cluster URLs, internal hostnames, IP addresses go into environment variables with generic defaults (e.g., `localhost`, `127.0.0.1`).
+- **No leaked paths** — user home directories, organization-specific paths, internal tool locations are parameterized.
+
+### 9. Write the Plan
+
+Save the plan to the appropriate location based on the project's existing structure:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+
+# Use existing directory structure if present
+if [ -d "${REPO_ROOT}/tests/plans" ]; then
+  PLAN_DIR="${REPO_ROOT}/tests/plans"
+elif [ -d "${REPO_ROOT}/test-plans" ]; then
+  PLAN_DIR="${REPO_ROOT}/test-plans"
+else
+  PLAN_DIR="${REPO_ROOT}/tests/plans"
+  # Create the directory
+fi
+```
+
+Write `<name>.md` to `PLAN_DIR`. If new common procedures were extracted, write them to `${PLAN_DIR}/common/`.
+
+### 10. Present Summary
+
+After writing the plan, present:
+- File path where the plan was saved
+- Number of phases and test cases
+- Whether any common steps were created or referenced
+- Invite the user to review and adjust before executing with `/oss-qe-verify`
+
+## Constraints
+
+You MUST:
+- Read and process `.oss-init.md` first.
+- Delegate to QE/QA/tester agents when available, not coding agents.
+- Follow the test plan format from step 7 — phases, PASS/FAIL assertions, env vars with defaults, summary matrix.
+- Parameterize all infrastructure values (images, hosts, IPs, namespaces, credentials).
+- Include a prerequisite check script and a test summary matrix in every plan.
+- Include negative tests when testing APIs, CLIs, or CRDs.
+- Make cleanup idempotent.
+- Search for and reference existing common steps before duplicating procedures.
+- Check for existing plans with the same name before creating.
+
+You MUST NOT:
+- Delegate plan creation to coding agents (backend-specialist, frontend-specialist, java-test-engineer, etc.) unless the user explicitly asks.
+- Hardcode credentials, tokens, internal hostnames, IPs, or organization-specific paths.
+- Write test steps without PASS/FAIL verification.
+- Use fixed `sleep` calls where polling or wait commands are available.
+- Use bash-only constructs without a compatibility wrapper.
+- Skip the test summary matrix at the end of the plan.
+
+## Acceptance Criteria
+
+- The project context is loaded via `.oss-init.md`.
+- The plan follows the established format: overview, prerequisites (tool table + check script + env vars), numbered phases, PASS/FAIL assertions on every step, negative tests, idempotent cleanup, test summary matrix.
+- All configurable values are environment variables with defaults.
+- Common procedures reference shared docs, not inline copies.
+- No credentials, internal hostnames, or organization-specific paths are hardcoded.
+- The plan is saved to the correct location in the project.
+- A summary is presented to the user with phase/test counts and an invitation to review.

--- a/commands/oss-qe-verify.md
+++ b/commands/oss-qe-verify.md
@@ -1,0 +1,211 @@
+# QE Verify
+
+Execute an existing test plan against the project, tracking results phase by phase. Each test step is run and recorded as PASS, FAIL, SKIP, or BLOCKED. Bugs found during execution are collected with evidence. A results table is **always** presented at the end — even on partial runs or early termination.
+
+This command is **execution only**. It runs an existing plan. To create a plan, use `/oss-qe-create-test-plan`. To fix a bug found during execution, use `/oss-fix-issue`.
+
+## Usage
+
+```
+/oss-qe-verify <test-plan> [description or guidance]
+```
+
+**Arguments:**
+- `<test-plan>` - Test plan name (e.g., `operator-basic-tests`) or path to a plan file
+- `[description or guidance]` - Optional guidance: which phases to run, environment overrides, specific concerns
+
+**Examples:**
+```
+/oss-qe-verify operator-basic-tests
+/oss-qe-verify smoke-tests Skip Phase 0, the cluster is already set up
+/oss-qe-verify cli-commands Only run Phase 3 (negative tests)
+/oss-qe-verify tests/plans/basic-ui-test.md
+```
+
+## Instructions
+
+### 1. Initialize Project Context
+
+**MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
+
+### 2. Parse Input
+
+Extract from the arguments:
+- **Test plan identifier** — either a short name (e.g., `operator-basic-tests`) or a file path
+- **Guidance** — optional: which phases to run/skip, environment overrides, specific focus areas
+
+### 3. Agent Delegation
+
+If a **qa-test-strategist**, **QE**, **QA**, or **tester** agent is available, delegate plan execution to it. The specialized agent should receive:
+- The project context (project-info, project-standards, project-guidelines)
+- The full test plan content
+- Any user guidance (phases to run/skip, overrides)
+- The results table format requirement (step 9)
+
+**MUST NOT** delegate to coding agents (backend-specialist, frontend-specialist, java-test-engineer, etc.) unless the user explicitly instructs otherwise.
+
+If no QE/QA agent is available, the main agent executes the plan directly.
+
+### 4. Locate Test Plan
+
+If the input is a file path, read it directly. Otherwise, search by name in this order:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+
+ls "${REPO_ROOT}/tests/plans/<name>.md" 2>/dev/null
+ls "${REPO_ROOT}/test-plans/<name>.md" 2>/dev/null
+ls "${REPO_ROOT}/.oss-ai-helper-rules/test-plans/<name>.md" 2>/dev/null
+```
+
+If no plan is found, ask the user to provide the path or run `/oss-qe-create-test-plan` first.
+
+### 5. Load and Present the Plan
+
+Read the full plan. Present a summary to the user before execution:
+
+```markdown
+## Test Plan: <title>
+
+- **Phases:** <count>
+- **Test cases:** <count>
+- **Prerequisites:** <tool list>
+- **Environment variables required:** <list>
+- **Scope:** <what this plan covers>
+```
+
+If the user provided guidance to skip or focus on specific phases, confirm the adjusted scope. Wait for user confirmation before proceeding to execution.
+
+### 6. Verify Prerequisites
+
+Run the prerequisite check from the plan:
+
+- **Tools** — verify each required tool is installed using the plan's verify commands
+- **Environment variables** — check that required variables are set (or have defaults)
+- **Connectivity** — if the plan requires external access (cluster, API, service), verify connectivity
+
+Report missing prerequisites clearly before starting. If critical prerequisites are missing, stop and present what needs to be resolved.
+
+### 7. Execute Phases Sequentially
+
+Work through the plan phase by phase, test by test:
+
+For each test step:
+1. **Run the command(s)** from the plan
+2. **Evaluate the assertion** — check the expected outcome against the actual result
+3. **Record the result:**
+   - **PASS** — assertion met, expected outcome observed
+   - **FAIL** — assertion not met, unexpected outcome. Capture: actual output, error messages, logs
+   - **SKIP** — test skipped per user guidance or because a prerequisite for this specific test is not met (not a plan-wide prerequisite failure)
+   - **BLOCKED** — a prior failure prevents this test from running
+4. **On FAIL:** collect evidence — error output, relevant logs, observed vs expected behavior. Continue to the next test unless the failure blocks subsequent tests.
+5. **On BLOCKED:** if a failure prevents the rest of a phase (or the entire plan) from continuing, stop execution and proceed directly to step 9 (results table). Present findings so far.
+
+**Progress updates:** provide brief updates between phases — phase name, pass/fail count so far.
+
+### 8. Bug Collection
+
+For each FAIL result, record:
+- **Test ID** — the phase and test number (e.g., `3.2`)
+- **Test name** — the test description from the plan
+- **Observed behavior** — what actually happened
+- **Expected behavior** — what the plan expected
+- **Evidence** — error output, log snippets, HTTP status codes, command output
+- **Severity** — Critical (blocks other tests or core functionality), High (significant but non-blocking), Medium (minor functional issue), Low (cosmetic or edge case)
+
+### 9. Produce Results Table (MANDATORY)
+
+**This step is NOT optional.** A results table MUST ALWAYS be presented after execution — whether the run completed fully, was partially executed, or terminated early due to a blocking failure.
+
+#### Results Format
+
+```markdown
+> :robot: **Note:** This verification was executed by a coding agent. Results should be reviewed by a human before acting on them. Test assertions are mechanical checks — they may miss context that a human would catch.
+
+## Verification Results — <test plan name>
+
+### Summary
+
+| Metric | Count |
+|--------|-------|
+| Total tests | <n> |
+| Passed | <n> |
+| Failed | <n> |
+| Skipped | <n> |
+| Blocked | <n> |
+
+### Overall Verdict: <PASS / PARTIAL PASS / FAIL>
+
+<!-- PASS: all tests passed -->
+<!-- PARTIAL PASS: some tests failed but core functionality works -->
+<!-- FAIL: critical tests failed or execution was blocked -->
+
+### Detailed Results
+
+| Phase | Test ID | Test Name | Result | Notes |
+|-------|---------|-----------|--------|-------|
+| 0 | 0.1 | <name> | PASS | |
+| 1 | 1.1 | <name> | FAIL | <brief reason> |
+| 1 | 1.2 | <name> | BLOCKED | Blocked by 1.1 |
+| ... | ... | ... | ... | ... |
+
+### Bugs Found
+
+<!-- Omit this section if no bugs were found -->
+
+| # | Test ID | Severity | Description |
+|---|---------|----------|-------------|
+| 1 | 1.1 | Critical | <what failed and why> |
+
+#### Bug 1 — <short title>
+- **Test:** <test ID> — <test name>
+- **Severity:** <Critical/High/Medium/Low>
+- **Observed:** <what happened>
+- **Expected:** <what should have happened>
+- **Evidence:** <error output, logs, commands>
+
+### Open Questions
+- <question 1>
+```
+
+### 10. Propose Follow-up
+
+Based on the results, offer one or more actions. Do NOT execute any without explicit confirmation.
+
+- **File bugs** — for each FAIL with a confirmed bug, offer to hand off to `/oss-create-issue` with a sanitized description.
+- **Fix issues** — for clear, reproducible bugs with an obvious fix path, offer to hand off to `/oss-fix-issue`.
+- **Update the plan** — if the plan has stale assertions, missing steps, or needs adjustment, offer to hand off to `/oss-qe-create-test-plan` for an update.
+- **Re-run** — if failures were caused by environment issues (flaky network, timing), offer to re-run the affected phases.
+
+## Constraints
+
+You MUST:
+- Read and process `.oss-init.md` first.
+- Delegate to QE/QA/tester agents when available, not coding agents.
+- Present the plan summary and get user confirmation before execution.
+- Verify prerequisites before starting test execution.
+- Record every test as PASS, FAIL, SKIP, or BLOCKED — no unrecorded tests.
+- Capture evidence for every FAIL (error output, logs, observed vs expected).
+- **ALWAYS present the results table (step 9)** — even on partial runs, early termination, or blocking failures.
+- Include the :robot: disclaimer in the results.
+- Stop execution if a failure blocks subsequent tests, and present findings so far.
+
+You MUST NOT:
+- Delegate execution to coding agents (backend-specialist, frontend-specialist, java-test-engineer, etc.) unless the user explicitly asks.
+- Skip the results table under any circumstances.
+- Mark a test as PASS when the assertion was not met.
+- Continue past a blocking failure without noting BLOCKED on subsequent tests.
+- Modify application source code — verification is read-only with respect to the codebase. Fixing is the job of `/oss-fix-issue`.
+- Silently drop test results — every test in the executed scope must appear in the results table.
+- Leak credentials, tokens, or internal infrastructure details in the results output.
+
+## Acceptance Criteria
+
+- The project context is loaded via `.oss-init.md`.
+- The test plan is located and presented to the user before execution.
+- Prerequisites are verified before starting.
+- Each test step is executed and recorded with a clear result (PASS/FAIL/SKIP/BLOCKED).
+- Evidence is captured for every failure.
+- A results table is presented with summary counts, detailed per-test results, and an overall verdict.
+- Bugs are listed with severity, observed/expected behavior, and evidence.
+- Follow-up actions are proposed with the appropriate downstream commands named.

--- a/install.sh
+++ b/install.sh
@@ -49,6 +49,8 @@ COMMAND_FILES=(
     "commands/oss-security-scan.md"
     "commands/oss-install-info.md"
     "commands/oss-create-rules.md"
+    "commands/oss-qe-create-test-plan.md"
+    "commands/oss-qe-verify.md"
 )
 
 # Project rule files are no longer bundled with the installer. They live in a


### PR DESCRIPTION
## Summary

- Add fully structured `/oss-qe-create-test-plan` and `/oss-qe-verify` commands, replacing the previous stubs (~24 lines each → ~200 lines each)
- Both commands follow the established OSS Helper pattern: project init via `.oss-init.md`, agent delegation, structured instructions, MUST/MUST NOT constraints, and acceptance criteria
- Agent delegation prefers QE/QA/tester agents and explicitly forbids coding agents from writing test plans

### `/oss-qe-create-test-plan`
Generates test plans following the project's conventions: numbered phases, env vars with defaults, PASS/FAIL assertions on every step, reusable common steps, negative tests, idempotent cleanup, and a test summary matrix.

### `/oss-qe-verify`
Executes test plans phase by phase, records results as PASS/FAIL/SKIP/BLOCKED, collects bugs with evidence and severity, and always presents a mandatory results table — even on partial runs or early termination.

## Test plan
- [ ] Verify both commands are loadable as skills
- [ ] Run `/oss-qe-create-test-plan` against a test project and confirm output follows the format conventions from `sample-plans/`
- [ ] Run `/oss-qe-verify` against an existing test plan and confirm the results table is produced