### PR TITLE
feat: add agent delegation sections to 13 commands

### DIFF
--- a/commands/oss-address-review.md
+++ b/commands/oss-address-review.md
@@ -17,6 +17,10 @@ Address review feedback on a pull request: read comments, categorize them, fix i
 
 **MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (`project-info.md`, `project-standards.md`, `project-guidelines.md`) is loaded.
 
+### Agent Delegation
+
+If you have access to agents specialized in **coding or implementation** (e.g., backend, frontend, or language-specific coding agents), you should delegate the code changes in steps 7–8 to one or more of those agents. Provide them with the review comments, affected files, and project standards context. If no specialized agents are available, perform all steps directly.
+
 ### 2. Identify the Pull Request
 
 - If a PR number or URL is provided, use it.

--- a/commands/oss-analyze-issue.md
+++ b/commands/oss-analyze-issue.md
@@ -17,6 +17,10 @@ Analyze an issue from the current project's issue tracker to gain deeper underst
 
 **MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
+### Agent Delegation
+
+If you have access to agents specialized in **software architecture or system design** (e.g., architecture or senior developer agents), you should delegate the codebase investigation (step 5) and root-cause analysis (step 6) to one or more of those agents. Provide them with the issue details and project context. If no specialized agents are available, perform all steps directly.
+
 ### 2. Parse Input
 
 Extract the issue ID from the argument based on the project's issue tracker type (from the project's `project-info.md`):

--- a/commands/oss-analyze-third-party-cve.md
+++ b/commands/oss-analyze-third-party-cve.md
@@ -22,6 +22,10 @@ This command is the dependency-side counterpart of `/oss-triage-security-report`
 
 If `project-security.md` names a location for third-party **"not affected" notes**, use it when proposing where to record the analysis (step 8).
 
+### Agent Delegation
+
+If you have access to agents specialized in **security analysis** (e.g., security or application-security agents), you should delegate the vulnerability analysis (steps 5–6) to one or more of those agents. Provide them with the CVE metadata, dependency coordinates, and project context. If no specialized agents are available, perform all steps directly.
+
 ### 2. Establish Boundaries
 
 **Before proceeding, remind the user:**

--- a/commands/oss-fix-backlog-task.md
+++ b/commands/oss-fix-backlog-task.md
@@ -22,6 +22,10 @@ Fix a task from the project's Backlog.md.
 
 Do NOT proceed with any further steps if the Backlog MCP server is not reachable.
 
+### Agent Delegation
+
+If you have access to agents specialized in **coding or implementation** (e.g., backend, frontend, or language-specific coding agents), you should delegate the implementation (step 8) to one or more of those agents. Provide them with the task details, affected files, and project standards. If no specialized agents are available, perform all steps directly.
+
 ### 2. Initialize Project Context
 
 **MANDATORY:** Read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.

--- a/commands/oss-fix-ci-errors.md
+++ b/commands/oss-fix-ci-errors.md
@@ -17,6 +17,10 @@ Download CI build reports, identify errors, and fix them properly.
 
 **MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
+### Agent Delegation
+
+If you have access to agents specialized in **coding or implementation** (e.g., backend, frontend, or language-specific coding agents), you should delegate the fix implementation (step 7) to one or more of those agents. Provide them with the error analysis, affected files, and project standards. If no specialized agents are available, perform all steps directly.
+
 ### 2. Parse Input
 
 - If a run ID is provided, use it directly.

--- a/commands/oss-fix-github-alert.md
+++ b/commands/oss-fix-github-alert.md
@@ -30,6 +30,10 @@ Read the **Issue tracker** field from the project's `project-info.md`. If the is
 
 Read the **GitHub repo** field — this is `<OWNER>/<REPO>` for the API calls below.
 
+### Agent Delegation
+
+If you have access to agents specialized in **coding or implementation** (e.g., backend, frontend, or language-specific coding agents) or **security analysis** (e.g., security or application-security agents), you should delegate the analysis (step 7) and fix implementation (step 10) to one or more of those agents. Provide them with the alert details, affected files, and project standards. If no specialized agents are available, perform all steps directly.
+
 ### 2. Parse Arguments
 
 Validate `<type>` is one of: `code-scanning`, `dependabot`, `secret-scanning`. If missing or invalid, stop and tell the user the accepted values.

--- a/commands/oss-fix-issue.md
+++ b/commands/oss-fix-issue.md
@@ -17,6 +17,10 @@ Fix an issue from the current project's issue tracker.
 
 **MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
+### Agent Delegation
+
+If you have access to agents specialized in **coding or implementation** (e.g., backend, frontend, or language-specific coding agents), you should delegate the implementation (step 7) to one or more of those agents. Provide them with the issue analysis, affected files, and project standards. If no specialized agents are available, perform all steps directly.
+
 ### 2. Parse Input
 
 Extract the issue ID from the argument based on the project's issue tracker type (from the project's `project-info.md`):

--- a/commands/oss-fix-sonarcloud.md
+++ b/commands/oss-fix-sonarcloud.md
@@ -24,6 +24,10 @@ Fix SonarCloud issues in the current project's codebase.
 
 Check the **SonarCloud component key** field in the project's `project-info.md`. If the project has no SonarCloud component key configured (shows `_(none)_`), stop and tell the user: "SonarCloud is not configured for this project."
 
+### Agent Delegation
+
+If you have access to agents specialized in **coding or implementation** (e.g., backend, frontend, or language-specific coding agents), you should delegate the fix application (step 3) to one or more of those agents. Provide them with the SonarCloud rule details, affected files, and project standards. If no specialized agents are available, perform all steps directly.
+
 ### 2. Gather Context
 
 #### A. Fetch Open Issues

--- a/commands/oss-review-pr.md
+++ b/commands/oss-review-pr.md
@@ -17,6 +17,10 @@ Review a pull request against the project's rules, standards, and contribution e
 
 **MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (`project-info.md`, `project-standards.md`, `project-guidelines.md`) is loaded.
 
+### Agent Delegation
+
+If you have access to agents specialized in **code review** or **software architecture** (e.g., code review or architecture agents), you should delegate the evaluation (steps 5–6) to one or more of those agents. Provide them with the PR diff, project rules, and git history context. If no specialized agents are available, perform all steps directly.
+
 ### 2. Parse Input
 
 Extract the pull request number:

--- a/commands/oss-review-prs.md
+++ b/commands/oss-review-prs.md
@@ -33,6 +33,10 @@ Nothing is posted to GitHub until you explicitly approve. By default the command
 
 **MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
+### Agent Delegation
+
+If you have access to agents specialized in **code review** (e.g., code review agents), you should use them for the per-PR evaluations in step 5. Each agent should receive the PR diff, project rules, and git history context, and return a structured verdict. If no specialized agents are available, perform all evaluations directly.
+
 ### 2. Parse Arguments
 
 Parse the optional arguments into local variables. Use these defaults when an argument is not provided:

--- a/commands/oss-security-scan.md
+++ b/commands/oss-security-scan.md
@@ -27,6 +27,10 @@ If `project-security.md` is present, use it for:
 - The **Private reporting channel** — used verbatim in the follow-up step (step 9) instead of guessing an address.
 - The **threat model anchor** — its scope, supported release lines, and any documented security posture inform what counts as in-scope (step 3).
 
+### Agent Delegation
+
+If you have access to agents specialized in **security analysis** (e.g., security or application-security agents), you should delegate the reasoning-based analysis (step 6) and finding triage (step 7) to one or more of those agents. Provide them with the threat model, scan scope, scanner output, and project context. If no specialized agents are available, perform all steps directly.
+
 ### 2. Establish Boundaries
 
 **Before proceeding, remind the user:**

--- a/commands/oss-triage-issue.md
+++ b/commands/oss-triage-issue.md
@@ -23,6 +23,10 @@ This command is read-only with respect to the tracker: it does NOT post comments
 
 **MANDATORY:** First, read and process the `.oss-init.md` file to detect the current project and load its rules. All subsequent steps assume the project context (project-info, project-standards, project-guidelines) is loaded.
 
+### Agent Delegation
+
+If you have access to agents specialized in **software architecture** or **QA/testing** (e.g., architecture, senior developer, or test strategy agents), you should delegate the reproduction (step 5) and classification (step 8) to one or more of those agents. Provide them with the issue details, codebase context, and project standards. If no specialized agents are available, perform all steps directly.
+
 ### 2. Parse Input
 
 Extract the issue ID from the argument based on the project's **Issue tracker** type (from `project-info.md`):

--- a/commands/oss-triage-security-report.md
+++ b/commands/oss-triage-security-report.md
@@ -21,6 +21,10 @@ This command does NOT publish any security details to public trackers. It is a l
 
 If `project-security.md` is present, use its **Private reporting channel** verbatim in the follow-up step (step 7) instead of guessing an address.
 
+### Agent Delegation
+
+If you have access to agents specialized in **security analysis** (e.g., security or application-security agents), you should delegate the claim verification (step 5) to one or more of those agents. Provide them with the extracted claims, affected files, and project context. If no specialized agents are available, perform all steps directly.
+
 ### 2. Acquire the Report
 
 Determine the report source from the argument:


### PR DESCRIPTION
## Summary

- Adds an "Agent Delegation" section to 13 commands that can benefit from specialized agents
- Uses generic capability categories (coding, code-review, architecture, security, QA/testing) rather than specific agent names, so any user's agent roster can match
- Each section specifies which steps to delegate and what context to provide to the agents

## Commands modified

| Command | Agent category |
|---|---|
| oss-address-review | coding |
| oss-analyze-issue | architecture |
| oss-analyze-third-party-cve | security |
| oss-fix-issue | coding |
| oss-fix-backlog-task | coding |
| oss-fix-ci-errors | coding |
| oss-fix-github-alert | coding, security |
| oss-fix-sonarcloud | coding |
| oss-review-pr | code-review, architecture |
| oss-review-prs | code-review |
| oss-triage-issue | architecture, QA/testing |
| oss-triage-security-report | security |
| oss-security-scan | security |

## Commands not modified

Procedural/simple commands (backport, create-issue, create-rules, find-task, quick-fix, list-*, merge-pr, pr-status, etc.) were deliberately left unchanged — their tasks are too mechanical or simple to benefit from agent delegation.