### PR TITLE
ci: add Markdown Lint CI workflow

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,21 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - "commands/**/*.md"
+      - "sample-plans/**/*.md"
+      - "*.md"
+      - ".markdownlint-cli2.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,18 @@
+config:
+  MD004:
+    style: "dash"
+  MD013: false
+  MD024:
+    siblings_only: true
+  MD025: false
+  MD033: false
+  MD036: false
+  MD060: false
+
+globs:
+  - "commands/**/*.md"
+  - "sample-plans/**/*.md"
+  - "*.md"
+
+ignores:
+  - "CLAUDE.md"


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to lint Markdown files on PRs to `main`
- Add `.markdownlint-cli2.yaml` config matching the conventions used in wanaku-ai/wanaku
- Covers `commands/`, `sample-plans/`, and root-level `.md` files

## Test plan

- [ ] Verify the workflow triggers on PRs that modify `.md` files
- [ ] Confirm lint rules catch formatting issues