### PR TITLE
Add project-local OSS Helper rules

### DIFF
--- a/.oss-ai-helper-rules/project-guidelines.md
+++ b/.oss-ai-helper-rules/project-guidelines.md
@@ -1,0 +1,18 @@
+# Project Guidelines
+
+This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
+
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
+- **Quick-fix branch:** `quick-fix/<short-slug>`
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
+- **PR creation:** always
+- **Find-task source:** GitHub labels
+- **Find-task beginner label:** `good first issue`
+- **Find-task experienced label:** `help wanted`
+- **Find-task intermediate:** _(none)_
+- **Scope-too-large redirect:** `/oss-create-issue`

--- a/.oss-ai-helper-rules/project-info.md
+++ b/.oss-ai-helper-rules/project-info.md
@@ -1,0 +1,13 @@
+# Project Information
+
+This rule file contains project-specific metadata used by OSS Helper commands. Commands detect the current project by matching `git remote get-url origin` against the remote pattern below.
+
+- **Remote pattern:** `Open-Harness-Engineering/ai-agents-oss-helper`
+- **GitHub repo:** `Open-Harness-Engineering/ai-agents-oss-helper`
+- **Issue tracker:** GitHub
+- **Issue tracker URL:** `https://github.com/Open-Harness-Engineering/ai-agents-oss-helper/issues`
+- **Issue ID format:** numeric
+- **SonarCloud component key:** _(none)_
+- **Documentation URL:** _(none)_
+- **Related repositories:** _(none)_
+- **Create-issue supported:** yes

--- a/.oss-ai-helper-rules/project-standards.md
+++ b/.oss-ai-helper-rules/project-standards.md
@@ -1,0 +1,11 @@
+# Project Standards
+
+This rule file contains build tools, commands, and code style constraints for the project. Commands read this file to determine how to build, test, and format code.
+
+- **Build tool:** none (Markdown/shell scripts only)
+- **Build command:** _(none)_
+- **Test command:** _(none)_
+- **Format command:** _(none)_
+- **Module-specific build:** no
+- **Parallelized Maven:** n/a
+- **Code style restrictions:** none


### PR DESCRIPTION
## Summary

- Add `.oss-ai-helper-rules/` directory with project-specific rules (project info, guidelines, and standards)
- Rules follow the same pattern as apache/camel PR #24251: no Version sections, no SonarCloud placeholders when unconfigured

These files allow AI coding assistants to pick up this project's conventions directly from the repo.

## Test plan

- [x] Verify `.oss-ai-helper-rules/` files contain correct project metadata
- [x] Verify Version sections and SonarCloud branch placeholder are removed (matching camel PR pattern)