### PR TITLE
fix: resolve merge conflict in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,12 +21,9 @@ AGENTS=("claude" "bob" "gemini" "opencode" "codex")
 # Command files to install (relative paths from repo root)
 COMMAND_FILES=(
     "commands/.oss-init.md"
-<<<<<<< HEAD
     "commands/_fragments/_common-init.md"
-    "commands/_fragments/README.md"
-=======
     "commands/_fragments/_build-workflow.md"
->>>>>>> f71373d (refactor: Extract build/test/format workflow into reusable fragment)
+    "commands/_fragments/README.md"
     "commands/oss-add-project.md"
     "commands/oss-fix-issue.md"
     "commands/oss-review-pr.md"


### PR DESCRIPTION
## Summary
- Resolved unmerged conflict markers in `install.sh` that included both sides of the `_fragments` file entries
- All three fragment files (`_common-init.md`, `_build-workflow.md`, `README.md`) are now listed in `COMMAND_FILES`

## Test plan
- [ ] Run `./install.sh claude` and verify all fragment files are installed