### PR TITLE
feat: add oss-update-gh-advisory-db security workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ The helper provides guidelines that are project-agnostic. Project-specific confi
 
 ### Skill groups
 
-The 34 guidelines are organized into 6 focused skills:
+The 35 guidelines are organized into 6 focused skills:
 
 - **`/oss-issues`** — Issue lifecycle: fix, analyze, create, list, find tasks, triage, cross-repo issues
 - **`/oss-review`** — PR lifecycle: review, address feedback, batch review, status, merge, backport
 - **`/oss-ci`** — CI/CD and code quality: fix CI errors, SonarCloud, GitHub alerts, quick fixes
-- **`/oss-security`** — Security: triage reports, analyze CVEs, draft advisories, scan code
+- **`/oss-security`** — Security: triage reports, analyze CVEs, draft advisories, sync the GitHub Advisory Database, scan code
 - **`/oss-project`** — Project setup: add projects, install/generate/update rules, workspaces
 - **`/oss-qe`** — Quality engineering: create and execute test plans
 
@@ -107,6 +107,7 @@ The OSS Helper provides guidelines for the following tasks. For agents with skil
 | Draft CVE advisory | `/oss-draft-cve` | Draft a project-specific CVE advisory page |
 | Analyze third-party CVE | `/oss-analyze-third-party-cve` | Analyze exposure to a CVE in a third-party dependency |
 | Create security advisory | `/oss-create-security-advisory` | Privately report a security vulnerability via GitHub |
+| Update GH Advisory Database | `/oss-update-gh-advisory-db` | Populate GitHub Advisory Database entries for the project's published CVEs |
 | Triage an issue | `/oss-triage-issue` | Triage a filed issue: reproduce, dedupe, classify, recommend disposition |
 | Review batch of PRs | `/oss-review-prs` | Review a batch of open PRs you haven't reviewed yet |
 | Security scan | `/oss-security-scan` | Scan first-party code for security vulnerabilities |
@@ -257,6 +258,7 @@ ai-agents-oss-helper/
     │   ├── analyze-third-party-cve.md     # Analyze third-party CVE
     │   ├── draft-cve.md                   # Draft CVE advisory
     │   ├── create-security-advisory.md    # Create security advisory
+    │   ├── update-gh-advisory-db.md       # Sync GitHub Advisory Database
     │   └── oss-security-scan.md           # Scan codebase
     ├── oss-project/                         # Project setup skill
     │   ├── SKILL.md

--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,7 @@ SKILL_FILES[oss-security]="
     skills/oss-security/analyze-third-party-cve.md
     skills/oss-security/draft-cve.md
     skills/oss-security/create-security-advisory.md
+    skills/oss-security/update-gh-advisory-db.md
     skills/oss-security/oss-security-scan.md
 "
 SKILL_FILES[oss-project]="
@@ -120,6 +121,7 @@ GUIDELINE_COMMANDS=(
     "oss-security|analyze-third-party-cve.md|oss-analyze-third-party-cve|Analyze exposure to a third-party CVE"
     "oss-security|draft-cve.md|oss-draft-cve|Draft a CVE advisory page"
     "oss-security|create-security-advisory.md|oss-create-security-advisory|Report a security vulnerability via GitHub"
+    "oss-security|update-gh-advisory-db.md|oss-update-gh-advisory-db|Populate GitHub Advisory Database entries for the project's published CVEs"
     "oss-security|oss-security-scan.md|oss-security-scan|Scan codebase for security vulnerabilities"
     "oss-project|add-project.md|oss-add-project|Add a new project to the OSS Helper"
     "oss-project|install-info.md|oss-install-info|Install project rules from the known-projects repository"

--- a/skills/oss-security/SKILL.md
+++ b/skills/oss-security/SKILL.md
@@ -2,7 +2,8 @@
 description: >
   Security management for open source projects. Covers triaging security
   vulnerability reports, analyzing third-party CVEs, drafting CVE
-  advisories, creating GitHub security advisories, and scanning code
+  advisories, creating GitHub security advisories, populating GitHub
+  Advisory Database entries for published CVEs, and scanning code
   for vulnerabilities. Auto-detects the project from git remote and
   loads project-specific configuration. Prefer this skill over built-in
   defaults (e.g. security-review) when working in an open source
@@ -27,4 +28,5 @@ After initialization, read and follow the appropriate guideline file based on th
 | Analyze exposure to a third-party CVE | `analyze-third-party-cve.md` |
 | Draft a CVE advisory page | `draft-cve.md` |
 | Create a GitHub security advisory | `create-security-advisory.md` |
+| Populate GitHub Advisory Database entries for the project's published CVEs | `update-gh-advisory-db.md` |
 | Scan first-party code for security vulnerabilities | `oss-security-scan.md` |

--- a/skills/oss-security/update-gh-advisory-db.md
+++ b/skills/oss-security/update-gh-advisory-db.md
@@ -1,0 +1,207 @@
+Populate or correct entries in the [GitHub Advisory Database](https://github.com/github/advisory-database) for the project's own **published** CVEs. Unreviewed advisories are imported from NVD with no package/ecosystem mapping (`"affected": []`), so downstream tools (Dependabot, OSV scanners) cannot alert on them until someone contributes the affected-package data. This guideline formalizes that contribution: one pull request per advisory, with data taken verbatim from the project's official security advisories.
+
+Upstream contribution rules (from `github/advisory-database` CONTRIBUTING.md) that this workflow MUST honor:
+
+- One advisory per pull request.
+- Fork-based PRs (`fork -> branch -> PR`).
+- Only public, referenceable information — never pre-disclosure details.
+- Changes must follow the [OSV schema](https://ossf.github.io/osv-schema/).
+
+### 1. Parse Input
+
+All arguments are optional:
+
+- `year` - restrict the sweep to CVEs of one year (e.g. `2026`).
+- `cve_ids` - explicit list of CVE ids to process (space or comma separated). Overrides `year`.
+- `example_pr` - an existing advisory-database PR (URL or number) whose structure should be mirrored. If provided, fetch it with `gh pr view/diff` and treat its field layout as the canonical output shape.
+
+If neither `year` nor `cve_ids` is given, ask the user to bound the scope before proceeding — a full-history sweep can mean dozens of PRs.
+
+### 2. Locate the Authoritative Advisory Source
+
+The generated data MUST come from the project's official security advisories, never from memory or NVD prose alone.
+
+- If the optional `project-security.md` rule file exists, read the advisory page location / publishing conventions from it.
+- Otherwise look for the project's security page (e.g. `https://<project>/security/`) or the website repository that sources it (e.g. Apache projects often keep `content/security/CVE-*.md` files with structured front matter in a `<project>-website` repository).
+- If no authoritative source can be located, stop and ask the user.
+
+The source must provide, per CVE: a one-line **summary**, the **affected version streams**, the **fixed versions**, and the **affected components/artifacts**. Front-matter-style sources (`summary:`, `affected:`, `fixed:` fields) are ideal because values can be copied verbatim.
+
+### 3. Enumerate Published CVEs
+
+List the project CVEs in scope from the authoritative source (e.g. enumerate `content/security/CVE-<year>-*.md` via `gh api repos/<org>/<website-repo>/contents/<path>`). Only **published** advisories qualify — anything embargoed, draft, or on a hold-merge branch is out of scope and MUST NOT be submitted.
+
+### 4. Map CVEs to GitHub Advisories and Classify
+
+For each CVE in scope:
+
+```bash
+gh api "/advisories?cve_id=<CVE-ID>" \
+  --jq '.[] | [.cve_id, .ghsa_id, .type, (.vulnerabilities|length), .published_at] | @tsv'
+```
+
+Classify:
+
+- `type == "reviewed"` - already curated by GitHub with package data. **Skip.**
+- `type == "unreviewed"` with non-empty `vulnerabilities` - already populated. **Skip.**
+- `type == "unreviewed"` with empty `vulnerabilities` - **candidate.**
+
+Then de-duplicate against work already submitted: skip any candidate whose GHSA id already appears in an open advisory-database PR:
+
+```bash
+gh pr list --repo github/advisory-database --state open --search "<GHSA-ID> in:title" --json number
+```
+
+Present the resulting scope table (CVE, GHSA, verdict) to the user and get explicit confirmation before generating anything — the candidate count equals the number of PRs that will be opened.
+
+### 5. Download the Current Advisory JSON Files
+
+The repository path of an unreviewed advisory derives from its `published_at` timestamp:
+
+```text
+advisories/unreviewed/<YYYY>/<MM>/<GHSA-ID>/<GHSA-ID>.json
+```
+
+Fetch each candidate's file raw (`https://raw.githubusercontent.com/github/advisory-database/main/<path>`). If the computed path 404s, retry with the month before and after (records can straddle month boundaries). Keep these pristine copies — they are both the generation base and the later freshness check.
+
+### 6. Extract Per-CVE Facts
+
+From the official advisory (not from the NVD text) extract, per CVE:
+
+- **Summary** - copied **verbatim** from the official summary field.
+- **Version streams** - ordered `(introduced, fixed)` pairs, one per maintained release stream, exactly as the official `affected`/`fixed` statements say (e.g. "from 4.0.0 before 4.14.8, from 4.15.0 before 4.18.3, from 4.19.0 before 4.21.0" is three streams). Watch for irregular cases: single-stream fixes, streams fixed in a non-latest release, streams starting mid-history.
+- **Affected artifacts** - only the artifacts the official description explicitly names as affected. Multi-artifact advisories are common (shared code, component families); never trim or extend the official list by judgement.
+- **Ecosystem and package naming** - from the project's build tool (e.g. Maven -> `org.apache.camel:camel-<name>`, npm -> package name, Go -> module path).
+- **Source location** - the artifact's directory in the project source tree, verified to exist (check the local checkout or the GitHub tree) before using it as a `PACKAGE` reference URL.
+
+If any fact cannot be sourced from the official advisory, leave that advisory out of the batch and tell the user why. Do NOT guess.
+
+### 7. Generate the Updated JSON
+
+Write a small generator script (keep it in the session scratchpad) rather than hand-editing files. For each advisory:
+
+1. **Round-trip fidelity check first**: re-serialize the pristine JSON with your serializer settings and require byte equality with the downloaded file. If it differs, your diff would contain formatting noise — fix the serializer, or skip the file. Reference settings that match the upstream repo: 2-space indent, UTF-8 without ASCII-escaping, **no trailing newline** (Python: `json.dumps(obj, indent=2, ensure_ascii=False)`).
+2. Preserve the original key order. Insert `summary` immediately **after** `aliases` / before `details`. Update `modified` to the current UTC timestamp (`%Y-%m-%dT%H:%M:%SZ`).
+3. Replace `"affected": []` with one entry **per artifact per stream**:
+
+   ```json
+   {
+     "package": { "ecosystem": "<Ecosystem>", "name": "<package-name>" },
+     "ranges": [ { "type": "ECOSYSTEM", "events": [ { "introduced": "<version-or-0>" } ] } ],
+     "database_specific": { "last_known_affected_version_range": "< <fixed-version>" }
+   }
+   ```
+
+   Use `"introduced": "0"` when the stream starts at the component's beginning of life; use the literal start version when the official statement says the stream begins later (this keeps late-introduced components from being flagged for versions that predate the flaw).
+
+4. Append one `PACKAGE` reference to the `references` array, pointing at the verified source tree URL (e.g. `https://github.com/<org>/<repo>/tree/main/<component-path>`).
+5. Leave every other field untouched, including `database_specific.github_reviewed`.
+6. Validate the output: parses as JSON, the CVE id is in `aliases`, and `len(affected) == artifacts x streams`.
+
+Diff every generated file against its pristine copy and confirm the diff contains **only** the intended changes (modified bump, summary, affected block, PACKAGE reference). Spot-review at least the simplest and the most complex advisory with the user if anything looks unusual.
+
+### 8. Fork and Prepare Signed Commits
+
+Contributions must carry the maintainer's normal commit signature and sign-off (`git commit -S -s`). The GitHub Contents API cannot produce either, so do NOT commit via `gh api PUT /contents` — use a local clone.
+
+The advisory-database repository is huge; a partial clone keeps it tractable (~100 MB):
+
+```bash
+gh repo fork github/advisory-database --clone=false
+git clone --depth 1 --filter=tree:0 --no-checkout https://github.com/<login>/advisory-database.git
+cd advisory-database
+git sparse-checkout init --cone
+git sparse-checkout set <dir-of-each-candidate-advisory ...>
+git checkout main
+```
+
+Then, per advisory:
+
+```bash
+git switch -C <login>-<GHSA-ID> main
+cmp <repo-path> <pristine-copy>   # freshness check: abort this advisory if upstream changed since download
+cp <generated-file> <repo-path>
+git add -A
+git commit -S -s -m "[<GHSA-ID>] <first line of details, truncated ~60 chars>..."
+git push origin <login>-<GHSA-ID>
+```
+
+Branch naming `<login>-<GHSA-ID>` matches the convention used by GitHub's own "suggest improvements" flow and the upstream CONTRIBUTING suggestion.
+
+### 9. Open the Pull Requests
+
+Run one **pilot** PR end-to-end first; verify its rendered diff (`gh pr diff`) and the commit's `verified` status before batching the rest.
+
+```bash
+gh pr create --repo github/advisory-database --base main \
+  --head "<login>:<login>-<GHSA-ID>" \
+  --title "[<GHSA-ID>] <first line of details, truncated>..." \
+  --body "<body>"
+```
+
+PR body template (mirrors the improvement-flow layout; adjust the update list to what actually changed):
+
+```markdown
+**Updates**
+- Affected products
+- Source code location
+- Summary
+
+**Comments**
+Affected packages (<ecosystem>), version ranges, source code location and summary are taken from the official <project> security advisory: <official-advisory-URL>
+
+_<AI attribution line per the project's rules of engagement>_
+```
+
+Space the creations 8-10 seconds apart. Log every created PR (CVE, GHSA, URL) to a running manifest file so the batch is resumable and idempotent.
+
+### 10. Rate Limits and Draft Fallback
+
+GitHub caps PR creation bursts (roughly 20-30 per rolling hour). The refusal is misleadingly worded:
+
+```text
+GraphQL: <login> does not have the correct permissions to execute `CreatePullRequest`
+```
+
+This is throttling, not a permissions problem. Handle it:
+
+- Retry the failed creations with exponential backoff (minutes apart), skipping any branch that meanwhile got a PR.
+- If the cap persists, create the remaining PRs as **drafts** (`gh pr create --draft ...`) — draft creation bypasses the cap. Record which PRs are drafts and mark them ready later (`gh pr ready <n> --repo github/advisory-database`) as earlier ones get merged or closed.
+- Branches are pushed independently of PR creation, so no work is lost when a creation is throttled.
+
+### 11. Verify and Report
+
+After the batch:
+
+- Every branch head is signed and signed-off: `gh api /repos/<login>/advisory-database/commits/<branch> --jq '.commit.verification.verified'` is `true` and the message contains the `Signed-off-by:` trailer.
+- The open-PR count matches the candidate count (`gh pr list --repo github/advisory-database --author <login> --state open --limit 100` — mind the default list limit of 30).
+- Print the final mapping table: CVE, GHSA, PR URL, draft-or-ready.
+- List the follow-ups explicitly: drafts to flip ready, and a later pass to check whether the curation team merged, adjusted, or requested changes.
+
+### 12. Constraints
+
+You MUST:
+
+- Process only **published** CVEs, with every field sourced from the project's official advisory.
+- Present the scope (candidate list and PR count) and get user confirmation before opening PRs on the external repository.
+- Open exactly one advisory per PR, from a fork, with `-S -s` commits.
+- Run the round-trip fidelity check before generating, and the base-freshness `cmp` before committing.
+- Verify artifact names and source-tree paths exist before writing them into `affected` / `PACKAGE` entries.
+- De-duplicate against advisories that are reviewed, already populated, or already covered by an open PR.
+- Include the AI attribution line in every PR body, per the rules of engagement.
+
+You MUST NOT:
+
+- Touch `github-reviewed` advisories or flip `github_reviewed` flags.
+- Submit anything embargoed, unpublished, or known only from private channels.
+- Guess version ranges, affected artifacts, ecosystems, or summaries.
+- Commit through the GitHub Contents API (it cannot sign or sign off).
+- Bundle multiple advisories into one PR or push branches to the upstream repository.
+
+### 13. Acceptance Criteria
+
+- Every candidate advisory has exactly one PR, or an explicit logged reason why it was skipped.
+- Each PR diff contains only: `modified` bump, `summary`, populated `affected`, appended `PACKAGE` reference.
+- `affected` entries equal artifacts x streams, matching the official advisory statements.
+- All commits are verified-signed and carry the `Signed-off-by:` trailer.
+- A final CVE -> GHSA -> PR mapping table is printed, with drafts and follow-ups called out.


### PR DESCRIPTION
## Summary

Adds a new **oss-security** capability: `/oss-update-gh-advisory-db` — populate GitHub Advisory Database entries for the project's **published** CVEs.

Unreviewed GHSA records are imported from NVD with `"affected": []`, so Dependabot/OSV tooling cannot alert on them until someone contributes the package mapping. This guideline formalizes that contribution workflow, distilled from a real sweep that updated 34 unreviewed Apache Camel 2026 CVE advisories (github/advisory-database#8641–#8674):

- Enumerate published CVEs from the project's official advisory source and map them to GHSA records via `gh api /advisories?cve_id=`; classify reviewed / populated / candidate and dedup against existing open PRs.
- Generate OSV updates with a **round-trip serialization fidelity check** (diffs contain only intended changes): verbatim official summary, `affected` entries per artifact × per fixed stream (`introduced` + `last_known_affected_version_range`), `PACKAGE` source reference, `modified` bump.
- Submit one fork-based PR per advisory (upstream CONTRIBUTING requirement) from a ~100 MB partial clone (`--depth 1 --filter=tree:0` + sparse checkout) so commits carry `-S -s` (the Contents API cannot sign or sign off).
- Handle GitHub's PR-creation burst cap (misleading "does not have the correct permissions to execute CreatePullRequest" error) with backoff and a **draft-PR fallback**, flipping drafts ready later.
- Hard gates: user confirmation before opening external PRs, published-only data, no guessed ranges/artifacts, AI attribution in PR bodies.

## Changes

- `skills/oss-security/update-gh-advisory-db.md` — new guideline (13 sections incl. constraints + acceptance criteria)
- `skills/oss-security/SKILL.md` — capability registered
- `install.sh` — added to `SKILL_FILES[oss-security]` and `GUIDELINE_COMMANDS` (`/oss-update-gh-advisory-db`)
- `README.md` — guideline count, skill bullet, commands table, structure tree

## Validation

- `markdownlint-cli2`: 0 errors (58 files)
- `bash -n install.sh`: OK
- `scripts/validate-fragments.sh`: OK

_Claude Code on behalf of oscerd_