### PR TITLE
feat: migrate loop/automation skills from forgebot-skills

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ SHARED_INIT="skills/_shared/init.md"
 
 # Skill definitions: "skill-dir|SKILL.md + guideline files..."
 # Each skill is a directory under skills/ containing a SKILL.md and guideline files.
-SKILL_DIRS=("oss-issues" "oss-review" "oss-ci" "oss-security" "oss-project" "oss-qe")
+SKILL_DIRS=("oss-issues" "oss-review" "oss-ci" "oss-security" "oss-project" "oss-qe" "oss-loop-core" "oss-ci-sweeper" "oss-review-loop" "oss-babysit" "oss-issue-loop")
 
 # Sub-agent definitions (installed for all tools in their native format)
 AGENT_FILES=(
@@ -527,6 +527,43 @@ install_skill_agent() {
     info "  Skills installed to: $skills_root/{${SKILL_DIRS[*]}}"
     info "  Commands installed to: $commands_dir"
     info "  Sub-agents installed to: $agents_dir"
+
+    # Install scripts (for loop preconditions, state management, triage)
+    local scripts_dir="$HOME/.$agent/scripts"
+    if mkdir -p "$scripts_dir"; then
+        local script_files=(
+            "scripts/check-pr-work.sh"
+            "scripts/check-review-replies.py"
+            "scripts/ci-sweeper-precondition.sh"
+            "scripts/detect-feedback.py"
+            "scripts/init-state-branch.sh"
+            "scripts/pull-state.sh"
+            "scripts/push-state.sh"
+            "scripts/triage-issues.py"
+            "scripts/triage-prs.py"
+            "scripts/update-state.py"
+            "scripts/wait-for-ci-failure.sh"
+            "scripts/wait-for-pr-update.sh"
+            "scripts/wait-for-pr-work.sh"
+        )
+        info "  Installing scripts..."
+        for script_file in "${script_files[@]}"; do
+            local filename
+            filename="$(basename "$script_file")"
+            local dest="$scripts_dir/$filename"
+            if [[ -f "$INSTALL_DIR/$script_file" ]]; then
+                if [[ "$use_symlinks" == "true" ]]; then
+                    ln -sf "$(cd "$INSTALL_DIR" && pwd -P)/$script_file" "$dest"
+                else
+                    cp "$INSTALL_DIR/$script_file" "$dest"
+                fi
+                chmod +x "$dest"
+                info "    Installed: $filename"
+            fi
+        done
+        info "  Scripts installed to: $scripts_dir"
+    fi
+
     info "  Rules directory: $rules_dir (project rules installed on demand)"
 }
 

--- a/scripts/check-pr-work.sh
+++ b/scripts/check-pr-work.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# check-pr-work.sh — Zero-cost precondition for the PR review loop.
+#
+# Two-tier check:
+#   Tier 1: ETag-based conditional request to GitHub Events API (free on 304).
+#   Tier 2: Deterministic PR triage against state.json (1 API call).
+#
+# Exits 0 (prints actionable PR count) if there is work to do.
+# Exits 1 if no actionable PRs found — the loop should skip this iteration.
+#
+# Costs:
+#   - Idle: 0 API calls (304 Not Modified doesn't count against rate limit)
+#   - Active: 1 API call (gh pr list)
+#   - First run: 2 API calls (no cached ETag -> always falls through)
+#
+# Usage: ./check-pr-work.sh [path/to/state.json]
+#
+# Reads the upstream repo from state.json, .oss-ai-helper-rules/project-info.md,
+# or git remote origin (in that order).
+#
+# Dependencies: gh CLI, python3
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+STATE_FILE="${1:-$REPO_ROOT/state.json}"
+
+# -- Detect upstream repo --
+REPO=""
+# Try state.json first
+if [[ -f "$STATE_FILE" ]]; then
+  REPO=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('project',''))" "$STATE_FILE" 2>/dev/null || true)
+fi
+# Fallback to project rules
+if [[ -z "$REPO" ]] && [[ -f "$REPO_ROOT/.oss-ai-helper-rules/project-info.md" ]]; then
+  REPO=$(grep -i 'Remote pattern:' "$REPO_ROOT/.oss-ai-helper-rules/project-info.md" | sed 's/.*Remote pattern:[* ]*//' | tr -d '`*' | xargs 2>/dev/null || true)
+fi
+# Fallback to git remote
+if [[ -z "$REPO" ]]; then
+  REPO=$(git remote get-url origin 2>/dev/null | sed -E 's#.*github.com[:/]##; s#\.git$##')
+fi
+if [[ -z "$REPO" ]]; then
+  echo "Cannot determine upstream repo. Skipping."
+  exit 1
+fi
+
+# -- Kill switch --
+if [[ -f "$STATE_FILE" ]]; then
+  PAUSED=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('paused',False))" "$STATE_FILE" 2>/dev/null || echo "False")
+  if [[ "$PAUSED" == "True" ]]; then
+    echo "Kill switch active. Skipping."
+    exit 1
+  fi
+fi
+
+# -- Tier 1: ETag-based conditional request --
+ETAG_FILE="${SCRIPT_DIR}/.pr-loop-etag-$(echo "$REPO" | tr '/' '-')"
+HEADER_TMP=$(mktemp)
+BODY_TMP=$(mktemp)
+trap 'rm -f "$HEADER_TMP" "$BODY_TMP"' EXIT
+
+CACHED_ETAG=""
+[ -f "$ETAG_FILE" ] && CACHED_ETAG=$(cat "$ETAG_FILE")
+
+ETAG_HEADER=()
+[ -n "$CACHED_ETAG" ] && ETAG_HEADER=(-H "If-None-Match: $CACHED_ETAG")
+
+HTTP_CODE=$(curl -s -o "$BODY_TMP" -D "$HEADER_TMP" -w "%{http_code}" \
+  -H "Authorization: token $(gh auth token)" \
+  -H "Accept: application/vnd.github+json" \
+  "${ETAG_HEADER[@]}" \
+  "https://api.github.com/repos/${REPO}/events?per_page=5" 2>/dev/null) || true
+
+NEW_ETAG=$(grep -i '^etag:' "$HEADER_TMP" 2>/dev/null | awk '{print $2}' | tr -d '\r\n' || true)
+[ -n "$NEW_ETAG" ] && echo -n "$NEW_ETAG" > "$ETAG_FILE"
+
+if [[ "$HTTP_CODE" == "304" ]]; then
+  echo "No repo activity since last check (ETag 304, free). Skipping."
+  exit 1
+fi
+
+# -- Tier 2: Deterministic triage against state.json --
+echo "Repo activity detected. Checking PRs..."
+exec python3 "$SCRIPT_DIR/triage-prs.py" "$REPO" "$STATE_FILE" --format summary

--- a/scripts/check-review-replies.py
+++ b/scripts/check-review-replies.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+check-review-replies.py — Detect unanswered replies to our review comments.
+
+Scans PRs we reviewed for replies to OUR inline comments or review body
+that we haven't responded to yet. These are questions/discussions directed
+at us that need a response.
+
+This is the "outbound babysitting" side — someone replied to our review
+and is waiting for an answer.
+
+Usage:
+    python3 check-review-replies.py <upstream-repo> <state-file> [--days 14]
+
+Output (JSON to stdout):
+    [
+      {
+        "pr": 2107,
+        "title": "fix: clamp truecolor SGR",
+        "thread_id": 12345,
+        "our_comment": "This could overflow if...",
+        "reply_author": "uchiha-bug-hunter",
+        "reply_body": "Good point, but what about...",
+        "reply_at": "2026-07-20T15:00:00Z",
+        "type": "question"  // question | acknowledgment | disagreement
+      }
+    ]
+
+Exit codes:
+    0 — unanswered replies found
+    1 — no unanswered replies
+    2 — error
+
+Dependencies: gh CLI, Python 3.8+
+"""
+
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone, timedelta
+
+AI_MARKER = "AI agent"
+ACKNOWLEDGMENT_PATTERNS = [
+    r"(?i)\b(thanks|thank you|done|fixed|applied|good catch|will do|addressed)\b"
+]
+QUESTION_PATTERNS = [
+    r"\?$", r"(?i)\b(why|how|what|could you|can you|should we|do you mean)\b"
+]
+
+def gh_json(args: list[str]) -> any:
+    result = subprocess.run(
+        ["gh"] + args,
+        capture_output=True, text=True, timeout=30
+    )
+    if result.returncode != 0:
+        return None
+    out = result.stdout.strip()
+    if not out:
+        return None
+    return json.loads(out)
+
+def load_state(path: str) -> dict:
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {"reviewed_prs": []}
+
+def classify_reply(body: str) -> str:
+    """Classify a reply as question, acknowledgment, or disagreement."""
+    body = body.strip()
+    for pat in QUESTION_PATTERNS:
+        if re.search(pat, body):
+            return "question"
+    for pat in ACKNOWLEDGMENT_PATTERNS:
+        if re.search(pat, body):
+            return "acknowledgment"
+    return "disagreement"
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Check for replies to our reviews")
+    parser.add_argument("repo", help="Upstream org/repo")
+    parser.add_argument("state_file", help="Path to state.json")
+    parser.add_argument("--days", type=int, default=14, help="Look back N days")
+    args = parser.parse_args()
+
+    state = load_state(args.state_file)
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=args.days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    recent = [p for p in state.get("reviewed_prs", []) if p.get("reviewed_at", "") >= cutoff]
+    if not recent:
+        sys.exit(1)
+
+    unanswered = []
+
+    for pr_entry in recent:
+        num = pr_entry["number"]
+        review_ts = pr_entry.get("reviewed_at", "")
+
+        # Get all review comments (inline) on this PR
+        comments = gh_json([
+            "api", f"repos/{args.repo}/pulls/{num}/comments",
+            "--paginate",
+            "--jq", "."
+        ])
+        if not comments or not isinstance(comments, list):
+            continue
+
+        # Find OUR comments (contain AI marker)
+        our_comment_ids = set()
+        our_comments = {}
+        for c in comments:
+            if AI_MARKER in (c.get("body") or ""):
+                our_comment_ids.add(c["id"])
+                our_comments[c["id"]] = c
+
+        if not our_comment_ids:
+            continue
+
+        # Find replies to our comments (in_reply_to_id points to ours)
+        for c in comments:
+            reply_to = c.get("in_reply_to_id")
+            if reply_to and reply_to in our_comment_ids:
+                # Is this reply from someone else (not us)?
+                reply_body = c.get("body", "")
+                if AI_MARKER in reply_body:
+                    continue  # Our own follow-up
+
+                # Check if we already replied after this reply
+                reply_created = c.get("created_at", "")
+                already_responded = False
+                for c2 in comments:
+                    if (c2.get("in_reply_to_id") == reply_to and
+                        AI_MARKER in (c2.get("body") or "") and
+                        c2.get("created_at", "") > reply_created):
+                        already_responded = True
+                        break
+
+                if not already_responded:
+                    unanswered.append({
+                        "pr": num,
+                        "title": pr_entry.get("title", ""),
+                        "thread_id": reply_to,
+                        "our_comment": (our_comments[reply_to].get("body", ""))[:200],
+                        "reply_author": c.get("user", {}).get("login", ""),
+                        "reply_body": reply_body,
+                        "reply_at": reply_created,
+                        "type": classify_reply(reply_body),
+                    })
+
+        # Also check issue comments (general PR discussion)
+        issue_comments = gh_json([
+            "api", f"repos/{args.repo}/issues/{num}/comments",
+            "--jq", f'[.[] | select(.created_at > "{review_ts}")]'
+        ])
+        if issue_comments and isinstance(issue_comments, list):
+            for c in issue_comments:
+                body = c.get("body", "")
+                author = c.get("user", {}).get("login", "")
+                # Skip our own comments
+                if AI_MARKER in body:
+                    continue
+                # Check if this mentions us or is a question about the review
+                if any(kw in body.lower() for kw in ["@", "review", "suggestion", "your comment"]):
+                    unanswered.append({
+                        "pr": num,
+                        "title": pr_entry.get("title", ""),
+                        "thread_id": c["id"],
+                        "our_comment": "(general PR discussion)",
+                        "reply_author": author,
+                        "reply_body": body[:500],
+                        "reply_at": c.get("created_at", ""),
+                        "type": classify_reply(body),
+                    })
+
+    if not unanswered:
+        sys.exit(1)
+
+    # Sort: questions first, then by date
+    type_order = {"question": 0, "disagreement": 1, "acknowledgment": 2}
+    unanswered.sort(key=lambda x: (type_order.get(x["type"], 9), x["reply_at"]))
+
+    json.dump(unanswered, sys.stdout, indent=2)
+    print()
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci-sweeper-precondition.sh
+++ b/scripts/ci-sweeper-precondition.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# CI Sweeper loop precondition script.
+#
+# Two-tier check:
+#   Tier 1: ETag-based conditional request to GitHub Events API (free on 304).
+#   Tier 2: Check each watched branch for a failed CI run (1 API call/branch).
+#
+# Exit 0  -> a failure exists on a watched branch; run the sweeper.
+# Exit 1  -> all branches green or in-progress; skip this iteration.
+#
+# Costs:
+#   - Idle: 0 API calls (304 Not Modified doesn't count against rate limit)
+#   - Active: 1 API call per watched branch
+#   - First run: 1 + N API calls (no cached ETag -> always falls through)
+#
+# This script runs BEFORE the model is invoked, so it costs zero tokens
+# when CI is green.  The full sweeper skill is only loaded when there is
+# an actual failure to triage.
+#
+# Configuration is read from LOOP.md in the project root.
+# Expected format in LOOP.md:
+#   | Watched branches | main, release-branch |
+#   | CI workflow | Main build |
+#
+# If LOOP.md is not found, falls back to checking 'main' branch only.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# -- Detect upstream repo --
+REPO=""
+if [[ -f "$REPO_ROOT/.oss-ai-helper-rules/project-info.md" ]]; then
+  REPO=$(grep -i 'Remote pattern:' "$REPO_ROOT/.oss-ai-helper-rules/project-info.md" | sed 's/.*Remote pattern:[* ]*//' | tr -d '`*' | xargs 2>/dev/null || true)
+fi
+if [[ -z "$REPO" ]]; then
+  REPO=$(git remote get-url origin 2>/dev/null | sed -E 's#.*github.com[:/]##; s#\.git$##')
+fi
+if [[ -z "$REPO" ]]; then
+  echo "precondition: cannot determine upstream repo -- skipping"
+  exit 1
+fi
+
+# -- Kill switch --
+STATE_FILE="$REPO_ROOT/STATE.md"
+if [[ -f "$STATE_FILE" ]] && grep -qP '^loop-pause-all' "$STATE_FILE" 2>/dev/null; then
+  echo "precondition: kill switch active -- skipping"
+  exit 1
+fi
+
+# -- Tier 1: ETag-based conditional request --
+ETAG_FILE="${SCRIPT_DIR}/.ci-loop-etag-$(echo "$REPO" | tr '/' '-')"
+HEADER_TMP=$(mktemp)
+BODY_TMP=$(mktemp)
+trap 'rm -f "$HEADER_TMP" "$BODY_TMP"' EXIT
+
+CACHED_ETAG=""
+[ -f "$ETAG_FILE" ] && CACHED_ETAG=$(cat "$ETAG_FILE")
+
+ETAG_HEADER=()
+[ -n "$CACHED_ETAG" ] && ETAG_HEADER=(-H "If-None-Match: $CACHED_ETAG")
+
+HTTP_CODE=$(curl -s -o "$BODY_TMP" -D "$HEADER_TMP" -w "%{http_code}" \
+  -H "Authorization: token $(gh auth token)" \
+  -H "Accept: application/vnd.github+json" \
+  "${ETAG_HEADER[@]}" \
+  "https://api.github.com/repos/${REPO}/events?per_page=5" 2>/dev/null) || true
+
+NEW_ETAG=$(grep -i '^etag:' "$HEADER_TMP" 2>/dev/null | awk '{print $2}' | tr -d '\r\n' || true)
+[ -n "$NEW_ETAG" ] && echo -n "$NEW_ETAG" > "$ETAG_FILE"
+
+if [[ "$HTTP_CODE" == "304" ]]; then
+  echo "precondition: no repo activity since last check (ETag 304, free) -- skipping"
+  exit 1
+fi
+
+# -- Tier 2: Check each watched branch --
+echo "precondition: repo activity detected -- checking CI status..."
+
+BRANCHES=()
+LOOP_FILE="$REPO_ROOT/LOOP.md"
+if [[ -f "$LOOP_FILE" ]]; then
+  raw=$(sed -n 's/.*Watched branches\s*|\s*\(.*\)\s*|.*/\1/p' "$LOOP_FILE" 2>/dev/null || true)
+  if [[ -n "$raw" ]]; then
+    IFS=',' read -ra BRANCHES <<< "$raw"
+    for i in "${!BRANCHES[@]}"; do
+      BRANCHES[$i]=$(echo "${BRANCHES[$i]}" | xargs)
+    done
+  fi
+
+  CI_WORKFLOW=$(sed -n 's/.*CI workflow\s*|\s*\(.*\)\s*|.*/\1/p' "$LOOP_FILE" 2>/dev/null | xargs || true)
+fi
+
+if [[ ${#BRANCHES[@]} -eq 0 ]]; then
+  BRANCHES=("main")
+fi
+
+for branch in "${BRANCHES[@]}"; do
+  if [[ -n "${CI_WORKFLOW:-}" ]]; then
+    conclusion=$(gh run list --repo "$REPO" --branch "$branch" \
+      --workflow "$CI_WORKFLOW" --limit 1 \
+      --json conclusion --jq '.[0].conclusion' 2>/dev/null || echo "unknown")
+  else
+    conclusion=$(gh api "repos/${REPO}/actions/runs?branch=${branch}&per_page=1&status=completed" \
+      --jq '.workflow_runs[0].conclusion // "none"' 2>/dev/null || echo "unknown")
+  fi
+
+  if [[ "$conclusion" == "failure" ]]; then
+    echo "precondition: FAILURE on $branch -- proceeding"
+    exit 0
+  fi
+done
+
+echo "precondition: all watched branches green -- skipping"
+exit 1

--- a/scripts/detect-feedback.py
+++ b/scripts/detect-feedback.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+detect-feedback.py — Deterministic feedback detection on past reviews.
+
+Scans reviewed PRs for feedback signals (dismissed, merged, comments)
+and updates learnings.json accordingly. No LLM needed.
+
+Usage:
+    python3 detect-feedback.py <upstream-repo> <state-file> <learnings-file> [--days 7]
+
+Example:
+    python3 detect-feedback.py jline/jline3 state.json learnings.json
+
+Exit codes:
+    0 — feedback detected and learnings updated
+    1 — no feedback found
+    2 — error
+
+Dependencies: gh CLI, Python 3.8+
+"""
+
+import json
+import subprocess
+import sys
+import uuid
+from datetime import datetime, timezone, timedelta
+
+def gh_json(args: list[str]) -> any:
+    result = subprocess.run(
+        ["gh"] + args,
+        capture_output=True, text=True, timeout=30
+    )
+    if result.returncode != 0:
+        return None
+    return json.loads(result.stdout) if result.stdout.strip() else None
+
+def parse_iso(ts: str) -> datetime:
+    ts = ts.replace("Z", "+00:00")
+    return datetime.fromisoformat(ts)
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+def load_json(path: str, default: dict) -> dict:
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return default
+
+def save_json(path: str, data: dict):
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+def update_learning(learnings: dict, finding_rule: str, file_pattern: str,
+                    signal: str, pr_number: int, pattern_desc: str) -> dict:
+    """Update or create a learning based on feedback signal."""
+    # Find existing
+    existing = None
+    for l in learnings.get("learnings", []):
+        if l.get("source", {}).get("finding_rule") == finding_rule and \
+           l.get("source", {}).get("file_pattern", "") == file_pattern:
+            existing = l
+            break
+
+    if existing:
+        if signal == "accepted":
+            existing["confidence"] = min(1.0, existing["confidence"] + 0.15)
+            existing["type"] = "accepted"
+        elif signal == "rejected":
+            existing["confidence"] = max(0.0, existing["confidence"] - 0.25)
+            existing["type"] = "rejected"
+
+        existing["occurrences"] = existing.get("occurrences", 1) + 1
+        existing["last_seen"] = now_iso()
+
+        # Auto-suppress
+        if existing["confidence"] < 0.1 and existing["occurrences"] >= 3:
+            existing["suppressed"] = True
+    else:
+        entry = {
+            "id": str(uuid.uuid4()),
+            "type": signal,
+            "source": {
+                "pr": pr_number,
+                "review_date": now_iso(),
+                "finding_rule": finding_rule,
+                "file_pattern": file_pattern,
+            },
+            "pattern": pattern_desc,
+            "action": "flag as issue" if signal == "accepted" else "suppress — dismissed by maintainer",
+            "confidence": 0.65 if signal == "accepted" else 0.25,
+            "occurrences": 1,
+            "last_seen": now_iso(),
+            "suppressed": False,
+        }
+        learnings.setdefault("learnings", []).append(entry)
+
+    return learnings
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Detect review feedback")
+    parser.add_argument("repo", help="Upstream org/repo")
+    parser.add_argument("state_file", help="Path to state.json")
+    parser.add_argument("learnings_file", help="Path to learnings.json")
+    parser.add_argument("--days", type=int, default=7, help="Look back N days")
+    args = parser.parse_args()
+
+    state = load_json(args.state_file, {"reviewed_prs": []})
+    learnings = load_json(args.learnings_file, {"version": "1.0", "project": args.repo, "learnings": []})
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=args.days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    recent = [p for p in state.get("reviewed_prs", []) if p.get("reviewed_at", "") >= cutoff]
+
+    if not recent:
+        print("No recent reviews to check for feedback.")
+        sys.exit(1)
+
+    updates = 0
+
+    for pr in recent:
+        num = pr["number"]
+        review_ts = pr.get("reviewed_at", "")
+
+        # Check our reviews on this PR
+        reviews = gh_json([
+            "api", f"repos/{args.repo}/pulls/{num}/reviews",
+            "--jq", '[.[] | select(.body | contains("AI agent")) | {id: .id, state: .state, body: .body}]'
+        ])
+        if not reviews:
+            continue
+
+        for review in reviews:
+            review_state = review.get("state", "")
+
+            if review_state == "DISMISSED":
+                # Our review was dismissed — rejected signal
+                rule = f"review-{num}"
+                learnings = update_learning(
+                    learnings, rule, "*",
+                    "rejected", num,
+                    f"Review on PR #{num} was dismissed"
+                )
+                updates += 1
+                print(f"  PR #{num}: review DISMISSED → rejected")
+
+        # Check if PR was merged
+        pr_data = gh_json([
+            "pr", "view", str(num), "--repo", args.repo,
+            "--json", "state,mergedAt"
+        ])
+        if pr_data and pr_data.get("state") == "MERGED":
+            # Check if our review had findings that were not addressed
+            if pr.get("verdict") == "REQUEST_CHANGES":
+                rule = f"review-{num}"
+                learnings = update_learning(
+                    learnings, rule, "*",
+                    "rejected", num,
+                    f"PR #{num} merged despite REQUEST_CHANGES — findings likely false positives"
+                )
+                updates += 1
+                print(f"  PR #{num}: merged despite REQUEST_CHANGES → rejected")
+            elif pr.get("verdict") == "APPROVE":
+                rule = f"review-{num}"
+                learnings = update_learning(
+                    learnings, rule, "*",
+                    "accepted", num,
+                    f"PR #{num} merged after APPROVE — review aligned with maintainer"
+                )
+                updates += 1
+                print(f"  PR #{num}: merged after APPROVE → accepted")
+
+        # Check for new commits after our review (suggestion applied?)
+        if review_ts:
+            commits = gh_json([
+                "api", f"repos/{args.repo}/pulls/{num}/commits",
+                "--jq", f'[.[] | select(.commit.committer.date > "{review_ts}")] | length'
+            ])
+            if commits and isinstance(commits, int) and commits > 0 and pr.get("verdict") in ("COMMENT", "REQUEST_CHANGES"):
+                rule = f"review-{num}"
+                learnings = update_learning(
+                    learnings, rule, "*",
+                    "accepted", num,
+                    f"PR #{num} had {commits} commit(s) after review — suggestions likely applied"
+                )
+                updates += 1
+                print(f"  PR #{num}: {commits} commit(s) after review → accepted")
+
+    if updates == 0:
+        print("No feedback signals detected.")
+        sys.exit(1)
+
+    save_json(args.learnings_file, learnings)
+    print(f"\n{updates} learning(s) updated in {args.learnings_file}")
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/init-state-branch.sh
+++ b/scripts/init-state-branch.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# init-state-branch.sh — Create a state branch on a fork with initial state files.
+#
+# Usage:
+#   ./init-state-branch.sh <fork-repo> <state-branch> <project-name> <loop-type>
+#
+# Example:
+#   ./init-state-branch.sh gnodet/jline3 pr-review-loop-state "JLine3" review-loop
+#   ./init-state-branch.sh gnodet/camel ci-sweeper-state "Camel" ci-sweeper
+#
+# Creates the branch via GitHub API and pushes initial state.json, loop-config.json,
+# and loop-run-log.json. No git checkout needed — uses API exclusively.
+#
+# Dependencies: gh CLI, jq (or Python 3 as fallback)
+
+set -euo pipefail
+
+FORK_REPO="${1:?Usage: $0 <fork-repo> <state-branch> <project-name> <loop-type>}"
+STATE_BRANCH="${2:?Missing state branch name}"
+PROJECT_NAME="${3:?Missing project name}"
+LOOP_TYPE="${4:?Missing loop type (review-loop or ci-sweeper)}"
+
+# Detect upstream from git remote or .oss-ai-helper-rules
+UPSTREAM_REPO=""
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+if [[ -f "$REPO_ROOT/.oss-ai-helper-rules/project-info.md" ]]; then
+  UPSTREAM_REPO=$(grep -i 'Remote pattern:' "$REPO_ROOT/.oss-ai-helper-rules/project-info.md" \
+    | sed 's/.*Remote pattern:[* ]*//' | tr -d '`*' | xargs 2>/dev/null || true)
+fi
+if [[ -z "$UPSTREAM_REPO" ]]; then
+  UPSTREAM_REPO=$(git remote get-url origin 2>/dev/null \
+    | sed -E 's#.*github.com[:/]##; s#\.git$##')
+fi
+
+echo "Initializing state branch for $PROJECT_NAME ($LOOP_TYPE)"
+echo "  Fork: $FORK_REPO"
+echo "  Upstream: $UPSTREAM_REPO"
+echo "  Branch: $STATE_BRANCH"
+
+# Get default branch SHA
+DEFAULT_BRANCH=$(gh api "repos/$FORK_REPO" --jq '.default_branch')
+HEAD_SHA=$(gh api "repos/$FORK_REPO/git/ref/heads/$DEFAULT_BRANCH" --jq '.object.sha')
+
+# Check if branch already exists
+if gh api "repos/$FORK_REPO/git/ref/heads/$STATE_BRANCH" &>/dev/null; then
+  echo "Branch $STATE_BRANCH already exists. Aborting."
+  exit 1
+fi
+
+# Create branch
+gh api "repos/$FORK_REPO/git/refs" --method POST \
+  -f ref="refs/heads/$STATE_BRANCH" \
+  -f sha="$HEAD_SHA" > /dev/null
+echo "Created branch: $STATE_BRANCH"
+
+# Generate initial state.json
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+STATE_JSON=$(cat <<ENDJSON
+{
+  "version": "1.0",
+  "project": "$UPSTREAM_REPO",
+  "project_name": "$PROJECT_NAME",
+  "loop_type": "$LOOP_TYPE",
+  "last_run": null,
+  "reviewed_prs": [],
+  "skipped_prs": [],
+  "review_queue": [],
+  "active_failures": [],
+  "escalated": [],
+  "resolved": [],
+  "created_at": "$NOW"
+}
+ENDJSON
+)
+
+# Generate loop-config.json
+if [[ "$LOOP_TYPE" == "review-loop" ]]; then
+  CONFIG_JSON=$(cat <<ENDJSON
+{
+  "version": "1.0",
+  "pattern": "pr-review-loop",
+  "project": "$UPSTREAM_REPO",
+  "project_name": "$PROJECT_NAME",
+  "cadence": "1h",
+  "max_items_per_run": 3,
+  "state_branch": "$STATE_BRANCH",
+  "level": "L2",
+  "budget": {
+    "max_runs_per_day": 24,
+    "max_tokens_per_day": 10000000,
+    "max_subagents_per_run": 6
+  },
+  "constraints": {
+    "never_merge": true,
+    "never_close": true,
+    "never_label": true,
+    "never_push": true,
+    "review_only": true,
+    "skip_drafts": true,
+    "skip_bots": ["dependabot", "renovate", "github-actions"],
+    "always_verify": true,
+    "always_check_history": true,
+    "ai_attribution": true
+  },
+  "operator": "$(git config user.name 2>/dev/null || echo 'unknown')"
+}
+ENDJSON
+)
+else
+  CONFIG_JSON=$(cat <<ENDJSON
+{
+  "version": "1.0",
+  "pattern": "ci-sweeper",
+  "project": "$UPSTREAM_REPO",
+  "project_name": "$PROJECT_NAME",
+  "cadence": "15m",
+  "max_items_per_run": 2,
+  "state_branch": "$STATE_BRANCH",
+  "level": "L2",
+  "watched_branches": ["main"],
+  "budget": {
+    "max_runs_per_day": 96,
+    "max_tokens_per_day": 10000000,
+    "max_fix_attempts": 3,
+    "max_files_per_fix": 5
+  },
+  "constraints": {
+    "never_merge": true,
+    "never_close": true,
+    "never_label": true,
+    "always_fork": true,
+    "always_draft": true,
+    "never_force_push": true,
+    "always_verify": true,
+    "never_disable_tests": true,
+    "ai_attribution": true
+  },
+  "operator": "$(git config user.name 2>/dev/null || echo 'unknown')"
+}
+ENDJSON
+)
+fi
+
+# Generate empty run log
+RUN_LOG_JSON='{"version": "1.0", "runs": []}'
+
+# Generate empty learnings
+LEARNINGS_JSON="{\"version\": \"1.0\", \"project\": \"$UPSTREAM_REPO\", \"learnings\": []}"
+
+# Push files via Contents API
+push_file() {
+  local file="$1"
+  local content="$2"
+  local msg="$3"
+  local b64
+  b64=$(echo -n "$content" | base64 -w0)
+  gh api "repos/$FORK_REPO/contents/$file" --method PUT \
+    -f message="$msg" \
+    -f branch="$STATE_BRANCH" \
+    -f content="$b64" > /dev/null
+  echo "  Pushed: $file"
+}
+
+push_file "state.json" "$STATE_JSON" "Initialize $LOOP_TYPE state"
+push_file "loop-config.json" "$CONFIG_JSON" "Initialize $LOOP_TYPE config"
+push_file "loop-run-log.json" "$RUN_LOG_JSON" "Initialize run log"
+push_file "learnings.json" "$LEARNINGS_JSON" "Initialize learnings"
+
+echo ""
+echo "State branch initialized: $STATE_BRANCH"
+echo ""
+echo "Files:"
+echo "  state.json         — reviewed/skipped PRs, queue, last run"
+echo "  loop-config.json   — cadence, budget, constraints"
+echo "  loop-run-log.json  — run history"
+echo "  learnings.json     — review learnings (feedback loop)"
+echo ""
+echo "To start the loop:"
+echo "  /loop 1h /oss-review-loop"

--- a/scripts/pull-state.sh
+++ b/scripts/pull-state.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# pull-state.sh — Download state files from the state branch via GitHub API.
+#
+# Usage:
+#   ./pull-state.sh <fork-repo> <state-branch> [output-dir]
+#
+# Example:
+#   ./pull-state.sh gnodet/jline3 pr-review-loop-state /tmp/loop-state
+#
+# Downloads state.json, loop-config.json, loop-run-log.json, learnings.json
+# from the state branch. Creates output-dir if needed. Defaults to current dir.
+#
+# Dependencies: gh CLI
+
+set -euo pipefail
+
+FORK_REPO="${1:?Usage: $0 <fork-repo> <state-branch> [output-dir]}"
+STATE_BRANCH="${2:?Missing state branch name}"
+OUTPUT_DIR="${3:-.}"
+
+mkdir -p "$OUTPUT_DIR"
+
+FILES=(state.json loop-config.json loop-run-log.json learnings.json)
+PULLED=0
+
+for file in "${FILES[@]}"; do
+  CONTENT=$(gh api "repos/$FORK_REPO/contents/$file?ref=$STATE_BRANCH" \
+    --jq '.content' 2>/dev/null || echo "")
+
+  if [[ -n "$CONTENT" ]]; then
+    echo "$CONTENT" | base64 -d > "$OUTPUT_DIR/$file"
+    echo "OK: $file"
+    PULLED=$((PULLED + 1))
+  else
+    echo "SKIP: $file (not found on $STATE_BRANCH)"
+  fi
+done
+
+echo ""
+echo "Pulled $PULLED file(s) to $OUTPUT_DIR"

--- a/scripts/push-state.sh
+++ b/scripts/push-state.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# push-state.sh — Push state files to the state branch via GitHub API.
+#
+# Usage:
+#   ./push-state.sh <fork-repo> <state-branch> [file1] [file2] ...
+#
+# Example:
+#   ./push-state.sh gnodet/jline3 pr-review-loop-state state.json loop-run-log.json learnings.json
+#
+# If no files specified, pushes all standard state files found in the current directory.
+#
+# Uses GitHub Contents API — no git checkout required, safe in worktrees.
+# Dependencies: gh CLI
+
+set -euo pipefail
+
+FORK_REPO="${1:?Usage: $0 <fork-repo> <state-branch> [files...]}"
+STATE_BRANCH="${2:?Missing state branch name}"
+shift 2
+
+# Default files if none specified
+if [[ $# -eq 0 ]]; then
+  FILES=()
+  for f in state.json loop-config.json loop-run-log.json learnings.json; do
+    [[ -f "$f" ]] && FILES+=("$f")
+  done
+  # Also check legacy markdown files
+  for f in STATE.md loop-budget.md loop-constraints.md loop-ledger.json loop-run-log.md; do
+    [[ -f "$f" ]] && FILES+=("$f")
+  done
+else
+  FILES=("$@")
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "No state files found to push."
+  exit 1
+fi
+
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+ERRORS=0
+
+for file in "${FILES[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    echo "SKIP: $file (not found)"
+    continue
+  fi
+
+  # Get existing SHA (needed for updates, empty for new files)
+  EXISTING_SHA=$(gh api "repos/$FORK_REPO/contents/$file?ref=$STATE_BRANCH" \
+    --jq '.sha' 2>/dev/null || echo "")
+
+  B64=$(base64 -w0 < "$file")
+
+  ARGS=(-f message="Update state $NOW" \
+        -f branch="$STATE_BRANCH" \
+        -f content="$B64")
+  [[ -n "$EXISTING_SHA" ]] && ARGS+=(-f sha="$EXISTING_SHA")
+
+  if gh api "repos/$FORK_REPO/contents/$file" --method PUT "${ARGS[@]}" > /dev/null 2>&1; then
+    echo "OK: $file"
+  else
+    echo "FAIL: $file"
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+if [[ $ERRORS -gt 0 ]]; then
+  echo ""
+  echo "$ERRORS file(s) failed to push."
+  exit 1
+fi
+
+echo ""
+echo "State pushed to $FORK_REPO@$STATE_BRANCH"

--- a/scripts/triage-issues.py
+++ b/scripts/triage-issues.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+triage-issues.py — Deterministic issue triage against JSON state.
+
+No LLM needed. Fetches open issues from GitHub (or Jira), filters out
+already-handled ones, and outputs actionable issues as JSON.
+
+Usage:
+    python3 triage-issues.py <upstream-repo> <state-file> [--max N] [--labels bug,help-wanted]
+    python3 triage-issues.py <upstream-repo> <state-file> --jira <project-key>
+
+Exit codes:
+    0 — actionable issues found (JSON to stdout)
+    1 — no actionable issues
+    2 — error
+
+Dependencies: gh CLI in PATH, Python 3.8+
+"""
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+def gh_json(args: list[str]):
+    """Run gh CLI and parse JSON output."""
+    result = subprocess.run(
+        ["gh"] + args,
+        capture_output=True, text=True, timeout=30
+    )
+    if result.returncode != 0:
+        return None
+    return json.loads(result.stdout) if result.stdout.strip() else None
+
+
+def load_state(path: str) -> dict:
+    """Load state.json, return empty state if missing."""
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {"handled_issues": [], "skipped_issues": []}
+
+
+def parse_iso(ts: str) -> datetime:
+    """Parse ISO 8601 timestamp."""
+    ts = ts.replace("Z", "+00:00")
+    return datetime.fromisoformat(ts)
+
+
+def fetch_github_issues(repo: str, labels: list[str] | None, limit: int) -> list[dict] | None:
+    """Fetch open issues from GitHub."""
+    search_parts = ["is:issue", "is:open", "-label:dependencies"]
+    if labels:
+        for label in labels:
+            search_parts.append(f"label:{label}")
+
+    return gh_json([
+        "issue", "list", "--repo", repo,
+        "--search", " ".join(search_parts),
+        "--limit", str(limit),
+        "--json", "number,title,author,createdAt,updatedAt,labels,assignees,comments"
+    ])
+
+
+def fetch_jira_issues(project_key: str) -> list[dict] | None:
+    """Fetch open issues from Jira via gh CLI (requires Jira MCP or API token)."""
+    # This is a placeholder — actual Jira integration depends on the project setup.
+    # Most OSS projects use GitHub issues or have a Jira→GitHub mirror.
+    print(f"Jira integration for {project_key} not yet implemented.", file=sys.stderr)
+    return None
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Deterministic issue triage")
+    parser.add_argument("repo", help="Upstream org/repo (e.g. apache/camel)")
+    parser.add_argument("state_file", help="Path to state.json")
+    parser.add_argument("--max", type=int, default=3, help="Max issues to return")
+    parser.add_argument("--labels", type=str, default=None,
+                        help="Comma-separated labels to filter (e.g. bug,help-wanted)")
+    parser.add_argument("--jira", type=str, default=None,
+                        help="Jira project key (e.g. CAMEL)")
+    parser.add_argument("--format", choices=["json", "summary"], default="json")
+    args = parser.parse_args()
+
+    state = load_state(args.state_file)
+
+    # Build lookup tables
+    handled = set()
+    for issue in state.get("handled_issues", []):
+        handled.add(issue["number"])
+
+    skipped = set()
+    for issue in state.get("skipped_issues", []):
+        skipped.add(issue["number"])
+
+    # Fetch issues
+    label_list = args.labels.split(",") if args.labels else None
+
+    if args.jira:
+        issues = fetch_jira_issues(args.jira)
+    else:
+        issues = fetch_github_issues(args.repo, label_list, limit=50)
+
+    if issues is None:
+        print("Failed to fetch issues.", file=sys.stderr)
+        sys.exit(2)
+
+    # Filter
+    BOT_AUTHORS = {"dependabot", "renovate", "github-actions",
+                   "app/dependabot", "app/github-actions"}
+    now = datetime.now(timezone.utc)
+    actionable = []
+
+    for issue in issues:
+        num = issue["number"]
+        author = issue.get("author", {}).get("login", "")
+        labels = [l.get("name", "") for l in issue.get("labels", [])]
+        assignees = [a.get("login", "") for a in issue.get("assignees", [])]
+
+        # Skip bots
+        if author in BOT_AUTHORS:
+            continue
+
+        # Skip already handled
+        if num in handled:
+            continue
+
+        # Skip permanently skipped
+        if num in skipped:
+            continue
+
+        # Skip if already assigned to someone (they're working on it)
+        if assignees:
+            continue
+
+        # Determine priority
+        created_at = issue.get("createdAt", "")
+        age_days = 0
+        try:
+            age_days = (now - parse_iso(created_at)).days
+        except (ValueError, TypeError):
+            pass
+
+        priority = "low"
+        if "bug" in labels or "regression" in labels:
+            priority = "high"
+        elif "good first issue" in labels or "good-first-issue" in labels:
+            priority = "medium"
+        elif "help wanted" in labels or "help-wanted" in labels:
+            priority = "medium"
+        elif age_days > 30:
+            priority = "medium"
+
+        actionable.append({
+            "number": num,
+            "title": issue["title"],
+            "author": author,
+            "labels": labels,
+            "priority": priority,
+            "age_days": age_days,
+            "comments": issue.get("comments", 0),
+        })
+
+    # Sort by priority
+    priority_order = {"high": 0, "medium": 1, "low": 2}
+    actionable.sort(key=lambda x: (priority_order.get(x["priority"], 3), -x["age_days"]))
+
+    # Limit
+    actionable = actionable[:args.max]
+
+    if not actionable:
+        print("No actionable issues.", file=sys.stderr)
+        sys.exit(1)
+
+    # Output
+    if args.format == "summary":
+        print(f"{len(actionable)} actionable issue(s):")
+        for issue in actionable:
+            labels_str = ", ".join(issue["labels"][:3]) if issue["labels"] else "-"
+            print(f"  #{issue['number']} [{issue['priority']}] {issue['title'][:60]} ({labels_str})")
+    else:
+        json.dump(actionable, sys.stdout, indent=2)
+        print()
+
+    sys.exit(0)

--- a/scripts/triage-prs.py
+++ b/scripts/triage-prs.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+triage-prs.py — Deterministic PR triage against JSON state.
+
+No LLM needed. Reads state.json, fetches open PRs from GitHub,
+checks for new comments/activity since last review, and outputs
+actionable PRs as JSON to stdout.
+
+Usage:
+    python3 triage-prs.py <upstream-repo> <state-file> [--max N] [--format json|summary]
+
+Example:
+    python3 triage-prs.py jline/jline3 state.json --max 3
+    python3 triage-prs.py apache/camel state.json --format summary
+
+Exit codes:
+    0 — actionable PRs found (output to stdout)
+    1 — no actionable PRs
+    2 — error
+
+Dependencies: gh CLI in PATH, Python 3.8+
+"""
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+def gh_json(args: list[str]) -> any:
+    """Run gh CLI and parse JSON output."""
+    result = subprocess.run(
+        ["gh"] + args,
+        capture_output=True, text=True, timeout=30
+    )
+    if result.returncode != 0:
+        return None
+    return json.loads(result.stdout) if result.stdout.strip() else None
+
+def load_state(path: str) -> dict:
+    """Load state.json, return empty state if missing."""
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {"reviewed_prs": [], "skipped_prs": []}
+
+def has_other_ai_review(repo: str, pr_number: int, operator: str) -> bool:
+    """Check if another AI agent (not ours) already reviewed this PR
+    AND the PR has not been updated since that review.
+
+    Detects reviews from other Claude Code operators by looking for the
+    AI disclaimer pattern. Skips reviews from our own operator to avoid
+    self-exclusion. Does NOT skip CodeRabbit/Copilot (complementary tools).
+
+    Returns False (= don't skip) if the PR has new commits after the
+    latest AI review — the previous review may be stale and we can take over.
+    """
+    reviews = gh_json([
+        "api", f"repos/{repo}/pulls/{pr_number}/reviews",
+        "--jq", '[.[] | {login: .user.login, body: .body, submitted_at: .submitted_at}]'
+    ])
+    if not reviews or not isinstance(reviews, list):
+        return False
+
+    # Find the latest AI review from another operator
+    latest_ai_review_ts = None
+    for r in reviews:
+        body = r.get("body", "") or ""
+        login = r.get("login", "") or ""
+        submitted = r.get("submitted_at", "") or ""
+        if "AI agent" in body and "Claude Code" in body and login != operator:
+            if latest_ai_review_ts is None or submitted > latest_ai_review_ts:
+                latest_ai_review_ts = submitted
+
+    if not latest_ai_review_ts:
+        return False
+
+    # Check if there are new commits after the AI review
+    latest_commit_date = gh_json([
+        "api", f"repos/{repo}/pulls/{pr_number}/commits",
+        "--jq", '.[-1].commit.committer.date'
+    ])
+    if latest_commit_date and isinstance(latest_commit_date, str):
+        if latest_commit_date > latest_ai_review_ts:
+            return False  # New commits since AI review — we can review
+
+    # Check if there are new comments after the AI review
+    new_comments = gh_json([
+        "api", f"repos/{repo}/issues/{pr_number}/comments",
+        "--jq", f'[.[] | select(.created_at > "{latest_ai_review_ts}")] | length'
+    ])
+    if new_comments and isinstance(new_comments, int) and new_comments > 0:
+        return False  # New comments since AI review — we can review
+
+    return True  # AI review exists, no new activity — skip
+
+def parse_iso(ts: str) -> datetime:
+    """Parse ISO 8601 timestamp."""
+    ts = ts.replace("Z", "+00:00")
+    return datetime.fromisoformat(ts)
+
+def check_new_comments(repo: str, pr_number: int, since: str) -> dict:
+    """Check for new comments on a PR since a timestamp.
+
+    Checks THREE sources (all via single API calls each):
+    1. Review comments (inline on diff)
+    2. Issue comments (general PR discussion)
+    3. New reviews submitted
+
+    Returns {has_activity: bool, new_comments: int, new_reviews: int,
+             latest_commit_after: bool, reason: str}
+    """
+    result = {"has_activity": False, "new_comments": 0, "new_reviews": 0,
+              "latest_commit_after": False, "reason": ""}
+
+    # 1. Review comments (inline on diff lines)
+    review_comments = gh_json([
+        "api", f"repos/{repo}/pulls/{pr_number}/comments",
+        "--jq", f'[.[] | select(.created_at > "{since}")] | length'
+    ])
+    if review_comments and isinstance(review_comments, int) and review_comments > 0:
+        result["new_comments"] += review_comments
+        result["has_activity"] = True
+
+    # 2. Issue comments (general discussion on the PR)
+    issue_comments = gh_json([
+        "api", f"repos/{repo}/issues/{pr_number}/comments",
+        "--jq", f'[.[] | select(.created_at > "{since}")] | length'
+    ])
+    if issue_comments and isinstance(issue_comments, int) and issue_comments > 0:
+        result["new_comments"] += issue_comments
+        result["has_activity"] = True
+
+    # 3. New reviews submitted (approvals, change requests, comments)
+    new_reviews = gh_json([
+        "api", f"repos/{repo}/pulls/{pr_number}/reviews",
+        "--jq", f'[.[] | select(.submitted_at > "{since}") | select(.body | contains("AI agent") | not)] | length'
+    ])
+    if new_reviews and isinstance(new_reviews, int) and new_reviews > 0:
+        result["new_reviews"] = new_reviews
+        result["has_activity"] = True
+
+    # 4. New commits (author pushed changes)
+    latest_commit_date = gh_json([
+        "api", f"repos/{repo}/pulls/{pr_number}/commits",
+        "--jq", '.[-1].commit.committer.date'
+    ])
+    if latest_commit_date and isinstance(latest_commit_date, str):
+        try:
+            if parse_iso(latest_commit_date) > parse_iso(since):
+                result["latest_commit_after"] = True
+                result["has_activity"] = True
+        except (ValueError, TypeError):
+            pass
+
+    # Build reason string
+    reasons = []
+    if result["latest_commit_after"]:
+        reasons.append("new commits")
+    if result["new_comments"] > 0:
+        reasons.append(f"{result['new_comments']} new comment(s)")
+    if result["new_reviews"] > 0:
+        reasons.append(f"{result['new_reviews']} new review(s)")
+    result["reason"] = ", ".join(reasons)
+
+    return result
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Deterministic PR triage")
+    parser.add_argument("repo", help="Upstream org/repo (e.g. jline/jline3)")
+    parser.add_argument("state_file", help="Path to state.json")
+    parser.add_argument("--max", type=int, default=3, help="Max PRs to return")
+    parser.add_argument("--format", choices=["json", "summary"], default="json")
+    args = parser.parse_args()
+
+    state = load_state(args.state_file)
+
+    # Detect operator's GitHub login (to exclude our own AI reviews from the check)
+    operator = state.get("operator_login", "")
+    if not operator:
+        result = subprocess.run(
+            ["gh", "api", "user", "--jq", ".login"],
+            capture_output=True, text=True, timeout=10
+        )
+        operator = result.stdout.strip() if result.returncode == 0 else ""
+
+    # Build lookup tables from state
+    reviewed = {}  # pr_number -> {reviewed_at, verdict, ...}
+    for pr in state.get("reviewed_prs", []):
+        reviewed[pr["number"]] = pr
+
+    skipped = set()
+    for pr in state.get("skipped_prs", []):
+        skipped.add(pr["number"])
+
+    # Fetch open PRs
+    prs = gh_json([
+        "pr", "list", "--repo", args.repo,
+        "--search", "is:pr is:open -is:draft",
+        "--limit", "50",
+        "--json", "number,title,author,createdAt,updatedAt,labels,reviewDecision,additions,deletions,changedFiles"
+    ])
+    if prs is None:
+        sys.exit(2)
+
+    # Filter
+    BOT_AUTHORS = {"dependabot", "renovate", "github-actions",
+                   "app/dependabot", "app/github-actions"}
+    now = datetime.now(timezone.utc)
+    actionable = []
+
+    for pr in prs:
+        num = pr["number"]
+        author = pr.get("author", {}).get("login", "")
+        is_bot = pr.get("author", {}).get("is_bot", False)
+        labels = [l.get("name", "") for l in pr.get("labels", [])]
+        updated_at = pr.get("updatedAt", "")
+
+        # Skip bots
+        if author in BOT_AUTHORS or is_bot:
+            continue
+
+        # Skip dependency-only PRs
+        if "dependencies" in labels:
+            continue
+
+        # Skip permanently skipped
+        if num in skipped:
+            continue
+
+        # Skip PRs already reviewed by another Claude Code operator
+        if num not in reviewed and has_other_ai_review(args.repo, num, operator):
+            continue
+
+        # Check if already reviewed
+        re_review = False
+        re_review_reason = ""
+        if num in reviewed:
+            review_ts = reviewed[num].get("reviewed_at", "")
+            if not review_ts:
+                continue
+
+            # Check for ANY new activity since our review:
+            # comments, reviews from others, new commits
+            activity = check_new_comments(args.repo, num, review_ts)
+            if not activity["has_activity"]:
+                continue  # Nothing new — skip
+
+            re_review = True
+            re_review_reason = activity["reason"]
+
+        # Determine priority
+        review_decision = pr.get("reviewDecision", "")
+        created_at = pr.get("createdAt", "")
+        age_days = 0
+        try:
+            age_days = (now - parse_iso(created_at)).days
+        except (ValueError, TypeError):
+            pass
+
+        if re_review:
+            # Re-reviews are always high priority — someone is waiting
+            priority = "high"
+        elif review_decision == "REVIEW_REQUIRED" or age_days > 7:
+            priority = "high"
+        elif updated_at and (now - parse_iso(updated_at)).days < 2:
+            priority = "medium"
+        else:
+            priority = "low"
+
+        actionable.append({
+            "number": num,
+            "title": pr["title"],
+            "author": author,
+            "priority": priority,
+            "age_days": age_days,
+            "additions": pr.get("additions", 0),
+            "deletions": pr.get("deletions", 0),
+            "changed_files": pr.get("changedFiles", 0),
+            "review_decision": review_decision,
+            "updated_at": updated_at,
+            "is_re_review": re_review,
+            "re_review_reason": re_review_reason,
+        })
+
+    # Sort: high > medium > low, then by age (oldest first)
+    priority_order = {"high": 0, "medium": 1, "low": 2}
+    actionable.sort(key=lambda x: (priority_order.get(x["priority"], 9), -x["age_days"]))
+
+    # Limit
+    actionable = actionable[:args.max]
+
+    if not actionable:
+        if args.format == "summary":
+            print("No actionable PRs found.")
+        sys.exit(1)
+
+    if args.format == "json":
+        json.dump(actionable, sys.stdout, indent=2)
+        print()
+    else:
+        print(f"{len(actionable)} PR(s) need review:")
+        for pr in actionable:
+            re = f" (re-review: {pr['re_review_reason']})" if pr["is_re_review"] else ""
+            print(f"  #{pr['number']} [{pr['priority']}] {pr['title']} — {pr['author']}{re}")
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update-state.py
+++ b/scripts/update-state.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+update-state.py — Deterministic state updates for the review loop.
+
+Updates state.json after a review is posted. No LLM needed.
+
+Usage:
+    # Record a review
+    python3 update-state.py state.json reviewed \\
+        --pr 2107 \\
+        --title "fix: clamp out-of-range truecolor SGR" \\
+        --author uchiha-bug-hunter \\
+        --verdict APPROVE \\
+        --notes "Bit-overflow fix. Good test."
+
+    # Skip a PR
+    python3 update-state.py state.json skip \\
+        --pr 2084 \\
+        --reason "Bot PR (dependabot)"
+
+    # Record a run
+    python3 update-state.py state.json run \\
+        --prs-checked 5 \\
+        --reviews-posted 2 \\
+        --tokens 52000
+
+    # Pause/unpause
+    python3 update-state.py state.json pause
+    python3 update-state.py state.json unpause
+
+    # Prune old entries (resolved > 30 days, runs > 30 days)
+    python3 update-state.py state.json prune
+
+Exit codes: 0 success, 1 error
+Dependencies: Python 3.8+
+"""
+
+import json
+import sys
+from datetime import datetime, timezone, timedelta
+
+def load_state(path: str) -> dict:
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {
+            "version": "1.0",
+            "project": "",
+            "last_run": None,
+            "reviewed_prs": [],
+            "skipped_prs": [],
+            "review_queue": [],
+            "paused": False,
+            "created_at": now_iso()
+        }
+
+def save_state(path: str, state: dict):
+    with open(path, "w") as f:
+        json.dump(state, f, indent=2)
+        f.write("\n")
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+def cmd_reviewed(state: dict, args) -> dict:
+    """Record a reviewed PR. Preserves interaction history for babysitting."""
+    now = now_iso()
+
+    # Find existing entry to preserve history
+    existing_idx = None
+    existing_entry = None
+    for i, p in enumerate(state["reviewed_prs"]):
+        if p["number"] == args.pr:
+            existing_idx = i
+            existing_entry = p
+            break
+
+    # Build interaction record
+    interaction = {
+        "at": now,
+        "verdict": args.verdict.upper(),
+        "notes": args.notes or "",
+    }
+
+    if existing_entry:
+        # Append to interaction history
+        history = existing_entry.get("interactions", [])
+        # If no history yet, seed it from the old flat fields
+        if not history and existing_entry.get("reviewed_at"):
+            history.append({
+                "at": existing_entry["reviewed_at"],
+                "verdict": existing_entry.get("verdict", ""),
+                "notes": existing_entry.get("notes", ""),
+            })
+        history.append(interaction)
+
+        existing_entry.update({
+            "reviewed_at": now,
+            "verdict": args.verdict.upper(),
+            "notes": args.notes or "",
+            "interactions": history,
+            "review_count": len(history),
+        })
+    else:
+        entry = {
+            "number": args.pr,
+            "title": args.title or "",
+            "author": args.author or "",
+            "reviewed_at": now,
+            "verdict": args.verdict.upper(),
+            "notes": args.notes or "",
+            "interactions": [interaction],
+            "review_count": 1,
+        }
+        state["reviewed_prs"].append(entry)
+
+    # Remove from queue if present
+    state["review_queue"] = [p for p in state.get("review_queue", []) if p.get("number") != args.pr]
+
+    return state
+
+def cmd_skip(state: dict, args) -> dict:
+    """Skip a PR permanently."""
+    entry = {
+        "number": args.pr,
+        "reason": args.reason or "",
+        "since": now_iso()
+    }
+
+    existing = [i for i, p in enumerate(state["skipped_prs"]) if p["number"] == args.pr]
+    if existing:
+        state["skipped_prs"][existing[0]] = entry
+    else:
+        state["skipped_prs"].append(entry)
+
+    return state
+
+def cmd_run(state: dict, args) -> dict:
+    """Record a loop run."""
+    state["last_run"] = {
+        "timestamp": now_iso(),
+        "prs_checked": args.prs_checked or 0,
+        "reviews_posted": args.reviews_posted or 0,
+        "tokens_estimate": args.tokens or 0
+    }
+    return state
+
+def cmd_pause(state: dict, _args) -> dict:
+    state["paused"] = True
+    return state
+
+def cmd_unpause(state: dict, _args) -> dict:
+    state["paused"] = False
+    return state
+
+def cmd_prune(state: dict, _args) -> dict:
+    """Prune old reviewed PRs (> 90 days) and old skipped PRs (> 90 days)."""
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=90)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    before_reviewed = len(state["reviewed_prs"])
+    state["reviewed_prs"] = [
+        p for p in state["reviewed_prs"]
+        if p.get("reviewed_at", "") >= cutoff
+    ]
+    pruned_reviewed = before_reviewed - len(state["reviewed_prs"])
+
+    if pruned_reviewed > 0:
+        print(f"Pruned {pruned_reviewed} reviewed PR(s) older than 90 days")
+
+    return state
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Deterministic state updates")
+    parser.add_argument("state_file", help="Path to state.json")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_rev = sub.add_parser("reviewed", help="Record a reviewed PR")
+    p_rev.add_argument("--pr", type=int, required=True)
+    p_rev.add_argument("--title", default="")
+    p_rev.add_argument("--author", default="")
+    p_rev.add_argument("--verdict", required=True, choices=["APPROVE", "COMMENT", "REQUEST_CHANGES"])
+    p_rev.add_argument("--notes", default="")
+
+    p_skip = sub.add_parser("skip", help="Skip a PR")
+    p_skip.add_argument("--pr", type=int, required=True)
+    p_skip.add_argument("--reason", default="")
+
+    p_run = sub.add_parser("run", help="Record a loop run")
+    p_run.add_argument("--prs-checked", type=int, default=0)
+    p_run.add_argument("--reviews-posted", type=int, default=0)
+    p_run.add_argument("--tokens", type=int, default=0)
+
+    sub.add_parser("pause", help="Activate kill switch")
+    sub.add_parser("unpause", help="Deactivate kill switch")
+    sub.add_parser("prune", help="Prune old entries")
+
+    args = parser.parse_args()
+    state = load_state(args.state_file)
+
+    handlers = {
+        "reviewed": cmd_reviewed,
+        "skip": cmd_skip,
+        "run": cmd_run,
+        "pause": cmd_pause,
+        "unpause": cmd_unpause,
+        "prune": cmd_prune,
+    }
+
+    state = handlers[args.command](state, args)
+    save_state(args.state_file, state)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/wait-for-ci-failure.sh
+++ b/scripts/wait-for-ci-failure.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+#
+# wait-for-ci-failure.sh — Blocking precondition for the CI sweeper loop.
+#
+# Polls the GitHub Events API using ETag-based conditional requests (free on
+# 304 Not Modified) until repository activity is detected, then checks
+# watched branches for CI failures.
+#
+# Designed to be called at the start of a /loop iteration in Claude Code:
+#   /loop 15m /oss-ci-sweeper
+#
+# Cost:
+#   - Idle: 0 API calls (304 doesn't count against rate limit)
+#   - Active: 1 API call per watched branch per activity burst
+#   - Zero LLM tokens consumed while waiting
+#
+# Usage: ./wait-for-ci-failure.sh [OPTIONS]
+#
+#   --timeout SECONDS   Max time to wait (default: 0 = no timeout, block forever)
+#   --interval SECONDS  Poll interval (default: 60)
+#   --repo OWNER/REPO   Override upstream repo detection
+#   --branches B1,B2    Override watched branches (default: from LOOP.md or "main")
+#   --workflow NAME     Override CI workflow name (default: from LOOP.md)
+#
+# Exit 0: CI failure found (stdout has branch + details)
+# Exit 1: timeout or all green (skip this iteration)
+#
+# Dependencies: curl, gh CLI
+
+set -euo pipefail
+
+# -- Parse arguments --
+TIMEOUT=0
+POLL_INTERVAL=60
+REPO_OVERRIDE=""
+BRANCHES_OVERRIDE=""
+WORKFLOW_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --timeout)    TIMEOUT="$2"; shift 2 ;;
+    --interval)   POLL_INTERVAL="$2"; shift 2 ;;
+    --repo)       REPO_OVERRIDE="$2"; shift 2 ;;
+    --branches)   BRANCHES_OVERRIDE="$2"; shift 2 ;;
+    --workflow)   WORKFLOW_OVERRIDE="$2"; shift 2 ;;
+    -*)           echo "Unknown option: $1" >&2; exit 1 ;;
+    *)            shift ;;
+  esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# -- Detect upstream repo --
+REPO="$REPO_OVERRIDE"
+if [[ -z "$REPO" ]] && [[ -f "$REPO_ROOT/.oss-ai-helper-rules/project-info.md" ]]; then
+  REPO=$(grep -i 'Remote pattern:' "$REPO_ROOT/.oss-ai-helper-rules/project-info.md" \
+    | sed 's/.*Remote pattern:[* ]*//' | tr -d '`*' | xargs 2>/dev/null || true)
+fi
+if [[ -z "$REPO" ]]; then
+  REPO=$(git remote get-url origin 2>/dev/null \
+    | sed -E 's#.*github.com[:/]##; s#\.git$##')
+fi
+if [[ -z "$REPO" ]]; then
+  echo "Cannot determine upstream repo." >&2
+  exit 1
+fi
+
+# -- Kill switch --
+STATE_FILE="$REPO_ROOT/STATE.md"
+if [[ -f "$STATE_FILE" ]] && grep -qP '^loop-pause-all' "$STATE_FILE" 2>/dev/null; then
+  echo "Kill switch active. Skipping."
+  exit 1
+fi
+
+# -- Detect watched branches and CI workflow --
+BRANCHES=()
+CI_WORKFLOW="$WORKFLOW_OVERRIDE"
+
+if [[ -n "$BRANCHES_OVERRIDE" ]]; then
+  IFS=',' read -ra BRANCHES <<< "$BRANCHES_OVERRIDE"
+else
+  LOOP_FILE="$REPO_ROOT/LOOP.md"
+  if [[ -f "$LOOP_FILE" ]]; then
+    raw=$(sed -n 's/.*Watched branches\s*|\s*\(.*\)\s*|.*/\1/p' "$LOOP_FILE" 2>/dev/null || true)
+    if [[ -n "$raw" ]]; then
+      IFS=',' read -ra BRANCHES <<< "$raw"
+      for i in "${!BRANCHES[@]}"; do
+        BRANCHES[$i]=$(echo "${BRANCHES[$i]}" | xargs)
+      done
+    fi
+    if [[ -z "$CI_WORKFLOW" ]]; then
+      CI_WORKFLOW=$(sed -n 's/.*CI workflow\s*|\s*\(.*\)\s*|.*/\1/p' "$LOOP_FILE" 2>/dev/null | xargs || true)
+    fi
+  fi
+fi
+[[ ${#BRANCHES[@]} -eq 0 ]] && BRANCHES=("main")
+
+# -- ETag polling loop --
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ETAG_FILE="${SCRIPT_DIR}/.wait-ci-etag-$(echo "$REPO" | tr '/' '-')"
+GH_TOKEN="$(gh auth token 2>/dev/null || echo "")"
+
+if [[ -z "$GH_TOKEN" ]]; then
+  echo "No GitHub token available (gh auth token failed)." >&2
+  exit 1
+fi
+
+CACHED_ETAG=""
+[[ -f "$ETAG_FILE" ]] && CACHED_ETAG=$(cat "$ETAG_FILE")
+
+START_TIME=$(date +%s)
+
+while true; do
+  # Check timeout (0 = no timeout)
+  ELAPSED=$(( $(date +%s) - START_TIME ))
+  if [[ $TIMEOUT -gt 0 ]] && [[ $ELAPSED -ge $TIMEOUT ]]; then
+    echo "Timeout (${TIMEOUT}s) — no CI failures detected."
+    exit 1
+  fi
+
+  # ETag-based conditional request (free on 304)
+  HEADER_TMP=$(mktemp)
+  BODY_TMP=$(mktemp)
+
+  ETAG_HEADER=()
+  [[ -n "$CACHED_ETAG" ]] && ETAG_HEADER=(-H "If-None-Match: $CACHED_ETAG")
+
+  HTTP_CODE=$(curl -s -o "$BODY_TMP" -D "$HEADER_TMP" -w "%{http_code}" \
+    -H "Authorization: token $GH_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    "${ETAG_HEADER[@]}" \
+    "https://api.github.com/repos/${REPO}/events?per_page=5" 2>/dev/null) || true
+
+  NEW_ETAG=$(grep -i '^etag:' "$HEADER_TMP" 2>/dev/null \
+    | awk '{print $2}' | tr -d '\r\n' || true)
+  [[ -n "$NEW_ETAG" ]] && echo -n "$NEW_ETAG" > "$ETAG_FILE"
+
+  rm -f "$HEADER_TMP" "$BODY_TMP"
+
+  if [[ "$HTTP_CODE" == "304" ]]; then
+    if [[ $TIMEOUT -gt 0 ]]; then
+      REMAINING=$(( TIMEOUT - ELAPSED ))
+      SLEEP_TIME=$(( POLL_INTERVAL < REMAINING ? POLL_INTERVAL : REMAINING ))
+      [[ $SLEEP_TIME -le 0 ]] && exit 1
+    else
+      SLEEP_TIME=$POLL_INTERVAL
+    fi
+    sleep "$SLEEP_TIME"
+    continue
+  fi
+
+  # Activity detected — check CI on each watched branch
+  echo "Activity detected on $REPO. Checking CI status..."
+
+  for branch in "${BRANCHES[@]}"; do
+    if [[ -n "$CI_WORKFLOW" ]]; then
+      conclusion=$(gh run list --repo "$REPO" --branch "$branch" \
+        --workflow "$CI_WORKFLOW" --limit 1 \
+        --json conclusion --jq '.[0].conclusion' 2>/dev/null || echo "unknown")
+    else
+      conclusion=$(gh api "repos/${REPO}/actions/runs?branch=${branch}&per_page=1&status=completed" \
+        --jq '.workflow_runs[0].conclusion // "none"' 2>/dev/null || echo "unknown")
+    fi
+
+    if [[ "$conclusion" == "failure" ]]; then
+      echo "CI FAILURE on branch '$branch' — proceeding."
+      exit 0
+    fi
+  done
+
+  # All green — keep polling
+  echo "All watched branches green. Resuming wait..."
+  if [[ $TIMEOUT -gt 0 ]]; then
+    REMAINING=$(( TIMEOUT - $(( $(date +%s) - START_TIME )) ))
+    SLEEP_TIME=$(( POLL_INTERVAL < REMAINING ? POLL_INTERVAL : REMAINING ))
+    [[ $SLEEP_TIME -le 0 ]] && exit 1
+  else
+    SLEEP_TIME=$POLL_INTERVAL
+  fi
+  sleep "$SLEEP_TIME"
+done

--- a/scripts/wait-for-pr-update.sh
+++ b/scripts/wait-for-pr-update.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+#
+# wait-for-pr-update.sh — Block until a specific PR has new activity.
+#
+# Polls the PR's events using ETag-based conditional requests (free on 304).
+# Returns when: new commit, new comment/review, CI status change, or merge.
+#
+# Usage: ./wait-for-pr-update.sh [OPTIONS] --pr NUMBER
+#
+#   --pr NUMBER         PR number (required)
+#   --repo OWNER/REPO   Override upstream repo detection
+#   --timeout SECONDS   Max wait (default: 0 = block forever)
+#   --interval SECONDS  Poll interval (default: 30)
+#
+# Exit 0: activity detected (stdout describes what changed)
+# Exit 1: timeout or error
+#
+# stdout signals (one per line):
+#   CI_FAILED           — latest CI run failed
+#   CI_GREEN            — latest CI run passed
+#   NEW_COMMENTS        — new comments or reviews since last check
+#   MERGED              — PR was merged
+#   CLOSED              — PR was closed without merge
+#   PUSHED              — new commits pushed
+#
+# Dependencies: curl, gh CLI
+
+set -euo pipefail
+
+# -- Parse arguments --
+TIMEOUT=0
+POLL_INTERVAL=30
+REPO_OVERRIDE=""
+PR_NUMBER=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)        PR_NUMBER="$2"; shift 2 ;;
+    --repo)      REPO_OVERRIDE="$2"; shift 2 ;;
+    --timeout)   TIMEOUT="$2"; shift 2 ;;
+    --interval)  POLL_INTERVAL="$2"; shift 2 ;;
+    -*)          echo "Unknown option: $1" >&2; exit 1 ;;
+    *)           shift ;;
+  esac
+done
+
+if [[ -z "$PR_NUMBER" ]]; then
+  echo "Usage: $0 --pr NUMBER [--repo OWNER/REPO] [--timeout N] [--interval N]" >&2
+  exit 1
+fi
+
+# -- Detect upstream repo --
+REPO="$REPO_OVERRIDE"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+if [[ -z "$REPO" ]] && [[ -f "$REPO_ROOT/.oss-ai-helper-rules/project-info.md" ]]; then
+  REPO=$(grep -i 'Remote pattern:' "$REPO_ROOT/.oss-ai-helper-rules/project-info.md" \
+    | sed 's/.*Remote pattern:[* ]*//' | tr -d '`*' | xargs 2>/dev/null || true)
+fi
+if [[ -z "$REPO" ]]; then
+  REPO=$(git remote get-url origin 2>/dev/null \
+    | sed -E 's#.*github.com[:/]##; s#\.git$##')
+fi
+if [[ -z "$REPO" ]]; then
+  echo "Cannot determine upstream repo." >&2
+  exit 1
+fi
+
+# -- Get initial state to compare against --
+GH_TOKEN="$(gh auth token 2>/dev/null || echo "")"
+if [[ -z "$GH_TOKEN" ]]; then
+  echo "No GitHub token available." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ETAG_FILE="${SCRIPT_DIR}/.wait-pr-${PR_NUMBER}-etag-$(echo "$REPO" | tr '/' '-')"
+
+# Snapshot: latest commit SHA, comment count, PR state
+get_pr_snapshot() {
+  gh api "repos/$REPO/pulls/$PR_NUMBER" \
+    --jq '{state: .state, merged: .merged, draft: .draft, head_sha: .head.sha, updated_at: .updated_at}' 2>/dev/null
+}
+
+get_ci_status() {
+  # Get combined status for head SHA
+  local sha="$1"
+  gh api "repos/$REPO/commits/$sha/status" --jq '.state' 2>/dev/null || echo "unknown"
+  # Also check check-runs (GitHub Actions uses checks, not statuses)
+  local check_conclusion
+  check_conclusion=$(gh api "repos/$REPO/commits/$sha/check-runs" \
+    --jq '[.check_runs[] | .conclusion // "pending"] | if any(. == "failure") then "failure" elif all(. == "success") then "success" else "pending" end' 2>/dev/null || echo "unknown")
+  echo "$check_conclusion"
+}
+
+INITIAL_SNAPSHOT=$(get_pr_snapshot)
+if [[ -z "$INITIAL_SNAPSHOT" ]]; then
+  echo "Failed to fetch PR #$PR_NUMBER." >&2
+  exit 1
+fi
+
+INITIAL_SHA=$(echo "$INITIAL_SNAPSHOT" | python3 -c "import sys,json; print(json.load(sys.stdin)['head_sha'])")
+INITIAL_STATE=$(echo "$INITIAL_SNAPSHOT" | python3 -c "import sys,json; print(json.load(sys.stdin)['state'])")
+INITIAL_MERGED=$(echo "$INITIAL_SNAPSHOT" | python3 -c "import sys,json; print(json.load(sys.stdin)['merged'])")
+INITIAL_UPDATED=$(echo "$INITIAL_SNAPSHOT" | python3 -c "import sys,json; print(json.load(sys.stdin)['updated_at'])")
+
+# Already merged?
+if [[ "$INITIAL_MERGED" == "True" ]]; then
+  echo "MERGED"
+  exit 0
+fi
+if [[ "$INITIAL_STATE" == "closed" ]]; then
+  echo "CLOSED"
+  exit 0
+fi
+
+CACHED_ETAG=""
+[[ -f "$ETAG_FILE" ]] && CACHED_ETAG=$(cat "$ETAG_FILE")
+
+START_TIME=$(date +%s)
+
+while true; do
+  # Check timeout
+  ELAPSED=$(( $(date +%s) - START_TIME ))
+  if [[ $TIMEOUT -gt 0 ]] && [[ $ELAPSED -ge $TIMEOUT ]]; then
+    echo "Timeout (${TIMEOUT}s) — no activity on PR #$PR_NUMBER."
+    exit 1
+  fi
+
+  # ETag-based poll on PR timeline events (free on 304)
+  HEADER_TMP=$(mktemp)
+  BODY_TMP=$(mktemp)
+
+  ETAG_HEADER=()
+  [[ -n "$CACHED_ETAG" ]] && ETAG_HEADER=(-H "If-None-Match: $CACHED_ETAG")
+
+  HTTP_CODE=$(curl -s -o "$BODY_TMP" -D "$HEADER_TMP" -w "%{http_code}" \
+    -H "Authorization: token $GH_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    "${ETAG_HEADER[@]}" \
+    "https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/timeline?per_page=5" 2>/dev/null) || true
+
+  NEW_ETAG=$(grep -i '^etag:' "$HEADER_TMP" 2>/dev/null \
+    | awk '{print $2}' | tr -d '\r\n' || true)
+  [[ -n "$NEW_ETAG" ]] && echo -n "$NEW_ETAG" > "$ETAG_FILE"
+
+  rm -f "$HEADER_TMP" "$BODY_TMP"
+
+  if [[ "$HTTP_CODE" == "304" ]]; then
+    # No activity — sleep
+    if [[ $TIMEOUT -gt 0 ]]; then
+      REMAINING=$(( TIMEOUT - ELAPSED ))
+      SLEEP_TIME=$(( POLL_INTERVAL < REMAINING ? POLL_INTERVAL : REMAINING ))
+      [[ $SLEEP_TIME -le 0 ]] && exit 1
+    else
+      SLEEP_TIME=$POLL_INTERVAL
+    fi
+    sleep "$SLEEP_TIME"
+    continue
+  fi
+
+  # Activity detected — determine what changed
+  CURRENT_SNAPSHOT=$(get_pr_snapshot)
+  if [[ -z "$CURRENT_SNAPSHOT" ]]; then
+    sleep "$POLL_INTERVAL"
+    continue
+  fi
+
+  CURRENT_SHA=$(echo "$CURRENT_SNAPSHOT" | python3 -c "import sys,json; print(json.load(sys.stdin)['head_sha'])")
+  CURRENT_STATE=$(echo "$CURRENT_SNAPSHOT" | python3 -c "import sys,json; print(json.load(sys.stdin)['state'])")
+  CURRENT_MERGED=$(echo "$CURRENT_SNAPSHOT" | python3 -c "import sys,json; print(json.load(sys.stdin)['merged'])")
+  CURRENT_UPDATED=$(echo "$CURRENT_SNAPSHOT" | python3 -c "import sys,json; print(json.load(sys.stdin)['updated_at'])")
+
+  SIGNALS=""
+
+  # Check merge
+  if [[ "$CURRENT_MERGED" == "True" ]]; then
+    echo "MERGED"
+    exit 0
+  fi
+
+  # Check closed
+  if [[ "$CURRENT_STATE" == "closed" ]]; then
+    echo "CLOSED"
+    exit 0
+  fi
+
+  # Check new commits
+  if [[ "$CURRENT_SHA" != "$INITIAL_SHA" ]]; then
+    SIGNALS="${SIGNALS}PUSHED\n"
+    INITIAL_SHA="$CURRENT_SHA"
+  fi
+
+  # Check CI status on current head
+  CI_STATUSES=$(get_ci_status "$CURRENT_SHA")
+  CI_STATUS=$(echo "$CI_STATUSES" | tail -1)  # check-runs result
+  COMMIT_STATUS=$(echo "$CI_STATUSES" | head -1)  # commit status
+
+  if [[ "$CI_STATUS" == "failure" ]] || [[ "$COMMIT_STATUS" == "failure" ]]; then
+    SIGNALS="${SIGNALS}CI_FAILED\n"
+  elif [[ "$CI_STATUS" == "success" ]] && [[ "$COMMIT_STATUS" != "failure" ]]; then
+    SIGNALS="${SIGNALS}CI_GREEN\n"
+  fi
+
+  # Check for new comments/reviews (updated_at changed but SHA didn't)
+  if [[ "$CURRENT_UPDATED" != "$INITIAL_UPDATED" ]] && [[ "$CURRENT_SHA" == "$INITIAL_SHA" ]]; then
+    SIGNALS="${SIGNALS}NEW_COMMENTS\n"
+  fi
+
+  INITIAL_UPDATED="$CURRENT_UPDATED"
+
+  if [[ -n "$SIGNALS" ]]; then
+    echo -e "$SIGNALS" | grep -v '^$'
+    exit 0
+  fi
+
+  # Activity detected but nothing actionable changed — keep polling
+  if [[ $TIMEOUT -gt 0 ]]; then
+    REMAINING=$(( TIMEOUT - $(( $(date +%s) - START_TIME )) ))
+    SLEEP_TIME=$(( POLL_INTERVAL < REMAINING ? POLL_INTERVAL : REMAINING ))
+    [[ $SLEEP_TIME -le 0 ]] && exit 1
+  else
+    SLEEP_TIME=$POLL_INTERVAL
+  fi
+  sleep "$SLEEP_TIME"
+done

--- a/scripts/wait-for-pr-work.sh
+++ b/scripts/wait-for-pr-work.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# wait-for-pr-work.sh — Blocking precondition for the PR review loop.
+#
+# Polls the GitHub Events API using ETag-based conditional requests (free on
+# 304 Not Modified) until repository activity is detected, then runs a
+# deterministic PR triage to check if there is actual review work to do.
+#
+# Designed to be called at the start of a /loop iteration in Claude Code:
+#   /loop 15m /oss-review-loop
+# The skill's step 0 runs this script. It blocks until there is work,
+# or until the timeout expires (exit 1 = skip this iteration).
+#
+# Cost:
+#   - Idle: 0 API calls (304 doesn't count against rate limit)
+#   - Active: 1 API call (gh pr list) per activity burst
+#   - Zero LLM tokens consumed while waiting
+#
+# Usage: ./wait-for-pr-work.sh [OPTIONS] [path/to/STATE.md]
+#
+#   --timeout SECONDS   Max time to wait (default: 0 = no timeout, block forever)
+#   --interval SECONDS  Poll interval (default: 60)
+#   --repo OWNER/REPO   Override upstream repo detection
+#
+# Exit 0: actionable PRs found (stdout has summary)
+# Exit 1: timeout or no work (skip this iteration)
+#
+# Dependencies: curl, gh CLI, python3
+
+set -euo pipefail
+
+# -- Parse arguments --
+TIMEOUT=0
+POLL_INTERVAL=60
+REPO_OVERRIDE=""
+STATE_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --timeout)   TIMEOUT="$2"; shift 2 ;;
+    --interval)  POLL_INTERVAL="$2"; shift 2 ;;
+    --repo)      REPO_OVERRIDE="$2"; shift 2 ;;
+    -*)          echo "Unknown option: $1" >&2; exit 1 ;;
+    *)           STATE_FILE="$1"; shift ;;
+  esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+STATE_FILE="${STATE_FILE:-$REPO_ROOT/STATE.md}"
+
+# -- Detect upstream repo --
+REPO="$REPO_OVERRIDE"
+if [[ -z "$REPO" ]] && [[ -f "$REPO_ROOT/.oss-ai-helper-rules/project-info.md" ]]; then
+  REPO=$(grep -i 'Remote pattern:' "$REPO_ROOT/.oss-ai-helper-rules/project-info.md" \
+    | sed 's/.*Remote pattern:[* ]*//' | tr -d '`*' | xargs 2>/dev/null || true)
+fi
+if [[ -z "$REPO" ]]; then
+  REPO=$(git remote get-url origin 2>/dev/null \
+    | sed -E 's#.*github.com[:/]##; s#\.git$##')
+fi
+if [[ -z "$REPO" ]]; then
+  echo "Cannot determine upstream repo." >&2
+  exit 1
+fi
+
+# -- Kill switch --
+if [[ -f "$STATE_FILE" ]] && grep -qP '^loop-pause-all' "$STATE_FILE" 2>/dev/null; then
+  echo "Kill switch active. Skipping."
+  exit 1
+fi
+
+# -- ETag polling loop --
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ETAG_FILE="${SCRIPT_DIR}/.wait-pr-etag-$(echo "$REPO" | tr '/' '-')"
+GH_TOKEN="$(gh auth token 2>/dev/null || echo "")"
+
+if [[ -z "$GH_TOKEN" ]]; then
+  echo "No GitHub token available (gh auth token failed)." >&2
+  exit 1
+fi
+
+CACHED_ETAG=""
+[[ -f "$ETAG_FILE" ]] && CACHED_ETAG=$(cat "$ETAG_FILE")
+
+START_TIME=$(date +%s)
+
+while true; do
+  # Check timeout (0 = no timeout)
+  ELAPSED=$(( $(date +%s) - START_TIME ))
+  if [[ $TIMEOUT -gt 0 ]] && [[ $ELAPSED -ge $TIMEOUT ]]; then
+    echo "Timeout (${TIMEOUT}s) — no actionable activity detected."
+    exit 1
+  fi
+
+  # ETag-based conditional request (free on 304)
+  HEADER_TMP=$(mktemp)
+  BODY_TMP=$(mktemp)
+
+  ETAG_HEADER=()
+  [[ -n "$CACHED_ETAG" ]] && ETAG_HEADER=(-H "If-None-Match: $CACHED_ETAG")
+
+  HTTP_CODE=$(curl -s -o "$BODY_TMP" -D "$HEADER_TMP" -w "%{http_code}" \
+    -H "Authorization: token $GH_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    "${ETAG_HEADER[@]}" \
+    "https://api.github.com/repos/${REPO}/events?per_page=5" 2>/dev/null) || true
+
+  NEW_ETAG=$(grep -i '^etag:' "$HEADER_TMP" 2>/dev/null \
+    | awk '{print $2}' | tr -d '\r\n' || true)
+  [[ -n "$NEW_ETAG" ]] && echo -n "$NEW_ETAG" > "$ETAG_FILE"
+
+  rm -f "$HEADER_TMP" "$BODY_TMP"
+
+  if [[ "$HTTP_CODE" == "304" ]]; then
+    # No activity — sleep and retry
+    if [[ $TIMEOUT -gt 0 ]]; then
+      REMAINING=$(( TIMEOUT - ELAPSED ))
+      SLEEP_TIME=$(( POLL_INTERVAL < REMAINING ? POLL_INTERVAL : REMAINING ))
+      [[ $SLEEP_TIME -le 0 ]] && exit 1
+    else
+      SLEEP_TIME=$POLL_INTERVAL
+    fi
+    sleep "$SLEEP_TIME"
+    continue
+  fi
+
+  # Activity detected — Tier 2: check if there are actionable PRs
+  echo "Activity detected on $REPO. Checking for actionable PRs..."
+
+  # Get open, non-draft PRs
+  PR_COUNT=$(gh pr list --repo "$REPO" \
+    --search "is:pr is:open -is:draft" \
+    --limit 30 \
+    --json number,updatedAt \
+    --jq 'length' 2>/dev/null || echo "0")
+
+  if [[ "$PR_COUNT" -gt 0 ]]; then
+    echo "$PR_COUNT open PR(s) found."
+    exit 0
+  fi
+
+  # False alarm — activity but no actionable PRs. Keep polling.
+  echo "Activity detected but no actionable PRs. Resuming wait..."
+  if [[ $TIMEOUT -gt 0 ]]; then
+    REMAINING=$(( TIMEOUT - $(( $(date +%s) - START_TIME )) ))
+    SLEEP_TIME=$(( POLL_INTERVAL < REMAINING ? POLL_INTERVAL : REMAINING ))
+    [[ $SLEEP_TIME -le 0 ]] && exit 1
+  else
+    SLEEP_TIME=$POLL_INTERVAL
+  fi
+  sleep "$SLEEP_TIME"
+done

--- a/skills/_shared/init.md
+++ b/skills/_shared/init.md
@@ -242,3 +242,28 @@ If the remote version differs from the local version (or the local version is un
    - Re-read the updated rule files before continuing
 
 4. If the user declines, continue with the existing local rules.
+
+## 4. OSS Helper Auto-Update
+
+Pull the latest skills from the remote repository on every invocation.
+
+### 4.1 Locate the skills repository
+
+```bash
+OSS_HELPER_DIR=""
+for dir in ~/.oss-helper "$HOME/.claude/oss-helper"; do
+  if [[ -d "$dir/.git" ]] || { [[ -L "$dir" ]] && [[ -d "$(readlink -f "$dir" 2>/dev/null)/.git" ]]; }; then
+    OSS_HELPER_DIR="$dir"
+    break
+  fi
+done
+```
+
+If `OSS_HELPER_DIR` is empty, skip this step — skills were not installed via
+git clone.
+
+### 4.2 Fetch and pull
+
+```bash
+git -C "$OSS_HELPER_DIR" pull --quiet 2>/dev/null
+```

--- a/skills/oss-babysit/SKILL.md
+++ b/skills/oss-babysit/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: oss-babysit
+description: >
+  Babysit skill group. Contains skills for babysitting PRs through their
+  full lifecycle: CI fix, undraft, review addressing, until merge.
+guidelines:
+  - babysit-pr.md: Babysit a PR from creation to merge
+---

--- a/skills/oss-babysit/babysit-pr.md
+++ b/skills/oss-babysit/babysit-pr.md
@@ -57,15 +57,11 @@ Run the blocking poll script and **wait for it to finish**:
 ~/.claude/scripts/wait-for-pr-update.sh --pr $PR_NUMBER --repo $REPO --timeout 3600
 ```
 
-> **🛑 WHILE THIS SCRIPT IS RUNNING, DO NOTHING ELSE.**
+> **🛑 Block waiting for this script to finish. Do NOT run any other command.**
 >
-> Do NOT run any other bash commands. Do NOT check CI status. Do NOT
-> check for comments. Do NOT read PR state. Do NOT run `gh` commands.
-> The script IS the check — it polls GitHub via ETag and returns ONLY
-> when something changes. Running parallel commands wastes tokens and
-> defeats the purpose.
->
-> **Wait for this single bash command to exit.** Then read its output.
+> This script will run for minutes or hours. That is expected.
+> Do NOT run any bash command while it is running — not `gh`, not `cat`,
+> not `date`, nothing. Just wait. When it exits, read the output and act.
 
 This command blocks for up to 1 hour. If nothing changes, it exits 1 — loop
 back to step 1 and block again. Do NOT treat a timeout as completion or failure.

--- a/skills/oss-babysit/babysit-pr.md
+++ b/skills/oss-babysit/babysit-pr.md
@@ -1,0 +1,195 @@
+---
+name: babysit-pr
+description: >
+  Babysit a PR from creation to merge. Monitors CI, fixes failures,
+  undrafts when CI is green, addresses review comments, and loops
+  until the PR is merged. Uses blocking ETag polling for zero-cost idle.
+user-invocable: true
+---
+
+# Babysit PR
+
+Continuously monitor and shepherd a PR through its lifecycle until it is
+merged. This skill is designed to be used with `/goal` (Claude Code native)
+or as the second phase of an issue-fix workflow.
+
+## Usage
+
+```
+/goal Babysit PR #1234 on apache/camel
+```
+
+Or from a ForgeBot task (after fixing an issue):
+
+```
+forge-task <repo> "Fix issue #567, then babysit the PR until merge"
+```
+
+## Inputs
+
+The PR number and repo can come from:
+- The goal/prompt text (e.g. "babysit PR #1234")
+- The current branch (detect from `gh pr view --json number`)
+- An argument passed by the calling skill
+
+## Process
+
+### 0. Detect PR
+
+```bash
+# From prompt or current branch
+PR_NUMBER=<extracted from prompt or detected>
+REPO=<from .oss-ai-helper-rules/project-info.md or git remote>
+
+# Get initial PR state
+gh pr view $PR_NUMBER --repo $REPO \
+  --json number,title,state,isDraft,mergeable,headRefName,statusCheckRollup,reviewDecision,mergedAt
+```
+
+If the PR is already merged, report and stop (`[GOAL_COMPLETE]`).
+If the PR is closed, report and stop (`[GOAL_BLOCKED]`).
+
+### 1. Main Loop — Wait for Activity
+
+Run the blocking poll script. It returns when something changes on the PR:
+
+```bash
+~/.claude/scripts/wait-for-pr-update.sh --pr $PR_NUMBER --repo $REPO
+```
+
+The script outputs one or more signals:
+- `MERGED` — PR was merged → we're done
+- `CLOSED` — PR was closed → we're blocked
+- `CI_FAILED` — CI run failed → fix it
+- `CI_GREEN` — CI passed → undraft + request reviewers
+- `NEW_COMMENTS` — new comments/reviews → address them
+- `PUSHED` — new commits → check CI status
+
+### 2. Handle Signals
+
+Based on the signal(s), take action:
+
+#### MERGED
+
+```
+[GOAL_COMPLETE]
+```
+
+#### CLOSED
+
+```
+[GOAL_BLOCKED]
+```
+
+#### CI_FAILED
+
+1. Fetch the failed CI run logs:
+   ```bash
+   gh run list --repo $REPO --branch $HEAD_BRANCH --status failure --limit 1 \
+     --json databaseId --jq '.[0].databaseId'
+   gh run view <RUN_ID> --repo $REPO --log-failed 2>/dev/null | tail -200
+   ```
+
+2. Diagnose the failure:
+   - Read the error message
+   - Check if it's a flaky test (compare with recent green runs on main)
+   - Check if it's a code issue introduced by this PR
+
+3. If fixable:
+   - Fix the code
+   - Run the relevant tests locally if possible
+   - Commit and push:
+     ```bash
+     git add <files>
+     git commit -m "fix: <description of CI fix>"
+     git push
+     ```
+
+4. If not fixable (infrastructure, flake, unrelated):
+   - Add a comment on the PR explaining the failure
+   - Continue waiting (next loop iteration)
+
+#### CI_GREEN
+
+1. Check if the PR is still a draft:
+   ```bash
+   IS_DRAFT=$(gh pr view $PR_NUMBER --repo $REPO --json isDraft --jq '.isDraft')
+   ```
+
+2. If draft, undraft it:
+   ```bash
+   gh pr ready $PR_NUMBER --repo $REPO
+   ```
+
+3. Request reviewers (if not already requested):
+   ```bash
+   # Check if reviewers are already assigned
+   REVIEWERS=$(gh pr view $PR_NUMBER --repo $REPO --json reviewRequests --jq '.reviewRequests | length')
+   if [[ "$REVIEWERS" == "0" ]]; then
+     # Let the project's CODEOWNERS or default reviewers handle it,
+     # or request specific reviewers if known from project rules
+     gh pr edit $PR_NUMBER --repo $REPO --add-reviewer <default-reviewers>
+   fi
+   ```
+
+4. Continue waiting for reviews or merge.
+
+#### NEW_COMMENTS
+
+1. Fetch new comments and reviews:
+   ```bash
+   gh pr view $PR_NUMBER --repo $REPO --json comments,reviews,latestReviews
+   ```
+
+2. Categorize each comment:
+   - **Review with changes requested** → address each finding
+   - **Question** → answer it
+   - **Suggestion (GitHub suggestion block)** → evaluate and apply if appropriate
+   - **Approval** → note it, continue waiting for merge
+   - **Nit / style feedback** → fix if trivial, otherwise note
+
+3. For each actionable comment:
+   - Read the relevant code
+   - Make the requested change (or explain why not)
+   - Push the fix
+   - Reply to the comment confirming the change:
+     ```bash
+     gh api repos/$REPO/pulls/$PR_NUMBER/comments/<ID>/replies \
+       --method POST -f body="Fixed in <commit-sha>."
+     ```
+
+4. After addressing all comments, push if changes were made.
+
+#### PUSHED
+
+New commits were pushed (possibly by us after a fix). Check the new CI
+status — don't take action yet, wait for CI to complete. The next
+`wait-for-pr-update.sh` call will return `CI_FAILED` or `CI_GREEN`.
+
+### 3. Loop Back
+
+After handling signals, go back to step 1. The script blocks again until
+the next activity.
+
+**Do NOT end with `[GOAL_COMPLETE]` unless the PR is merged.**
+**Do NOT end with `[GOAL_BLOCKED]` unless the PR is closed or you cannot
+proceed without human input.**
+
+## Constraints
+
+You MUST:
+- Wait for the blocking script between actions (zero-cost idle)
+- Fix CI failures before undrafting
+- Address all review comments before pushing
+- Include the issue reference in fix commits (e.g. "fix: address review feedback on #1234")
+- Reply to review comments when addressing them
+- Undraft only when CI is green
+
+You MUST NOT:
+- Merge the PR yourself (human or bot merges)
+- Close the PR
+- Force-push (use regular push)
+- Ignore review comments (address or explain why not)
+- Undraft while CI is failing
+- Spam reviewers (request review only once after CI goes green, not on every push)
+- End with `[GOAL_COMPLETE]` unless PR is merged

--- a/skills/oss-babysit/babysit-pr.md
+++ b/skills/oss-babysit/babysit-pr.md
@@ -51,11 +51,21 @@ If the PR is closed, report and stop (`[GOAL_BLOCKED]`).
 
 ### 1. Main Loop — Wait for Activity
 
-Run the blocking poll script. It returns when something changes on the PR:
+Run the blocking poll script and **wait for it to finish**:
 
 ```bash
 ~/.claude/scripts/wait-for-pr-update.sh --pr $PR_NUMBER --repo $REPO --timeout 3600
 ```
+
+> **🛑 WHILE THIS SCRIPT IS RUNNING, DO NOTHING ELSE.**
+>
+> Do NOT run any other bash commands. Do NOT check CI status. Do NOT
+> check for comments. Do NOT read PR state. Do NOT run `gh` commands.
+> The script IS the check — it polls GitHub via ETag and returns ONLY
+> when something changes. Running parallel commands wastes tokens and
+> defeats the purpose.
+>
+> **Wait for this single bash command to exit.** Then read its output.
 
 This command blocks for up to 1 hour. If nothing changes, it exits 1 — loop
 back to step 1 and block again. Do NOT treat a timeout as completion or failure.
@@ -192,6 +202,7 @@ again. The script blocks (zero cost) until the next event.
 
 You MUST:
 - Wait for the blocking script between actions (zero-cost idle)
+- Do NOTHING while a blocking script is running — no parallel bash commands, no status checks
 - Fix CI failures before undrafting
 - Address all review comments before pushing
 - Include the issue reference in fix commits (e.g. "fix: address review feedback on #1234")

--- a/skills/oss-babysit/babysit-pr.md
+++ b/skills/oss-babysit/babysit-pr.md
@@ -54,8 +54,11 @@ If the PR is closed, report and stop (`[GOAL_BLOCKED]`).
 Run the blocking poll script. It returns when something changes on the PR:
 
 ```bash
-~/.claude/scripts/wait-for-pr-update.sh --pr $PR_NUMBER --repo $REPO
+~/.claude/scripts/wait-for-pr-update.sh --pr $PR_NUMBER --repo $REPO --timeout 3600
 ```
+
+This command blocks for up to 1 hour. If nothing changes, it exits 1 — loop
+back to step 1 and block again. Do NOT treat a timeout as completion or failure.
 
 The script outputs one or more signals:
 - `MERGED` — PR was merged → we're done
@@ -172,8 +175,8 @@ After handling signals, go back to step 1. The script blocks again until
 the next activity.
 
 **Do NOT end with `[GOAL_COMPLETE]` unless the PR is merged.**
-**Do NOT end with `[GOAL_BLOCKED]` unless the PR is closed or you cannot
-proceed without human input.**
+**Do NOT end with `[GOAL_BLOCKED]` unless the PR is closed.**
+**Waiting for human review is NOT "blocked" — it is normal. Keep waiting.**
 
 ## Constraints
 
@@ -193,3 +196,4 @@ You MUST NOT:
 - Undraft while CI is failing
 - Spam reviewers (request review only once after CI goes green, not on every push)
 - End with `[GOAL_COMPLETE]` unless PR is merged
+- End with `[GOAL_BLOCKED]` unless PR is closed (waiting for review is NOT blocked)

--- a/skills/oss-babysit/babysit-pr.md
+++ b/skills/oss-babysit/babysit-pr.md
@@ -165,14 +165,24 @@ Based on the signal(s), take action:
 
 #### PUSHED
 
-New commits were pushed (possibly by us after a fix). Check the new CI
-status — don't take action yet, wait for CI to complete. The next
-`wait-for-pr-update.sh` call will return `CI_FAILED` or `CI_GREEN`.
+New commits were pushed (possibly by us after a fix).
+
+> **🛑 Do NOT poll CI status.** Do NOT run `gh run list` or `gh pr checks`
+> in a loop. Go directly to step 1 — the blocking `wait-for-pr-update.sh`
+> script will detect when CI completes and return `CI_FAILED` or `CI_GREEN`.
+> Polling CI yourself wastes tokens.
+
+**Action:** Go to step 1 immediately. Do nothing else.
 
 ### 3. Loop Back
 
-After handling signals, go back to step 1. The script blocks again until
-the next activity.
+After handling signals, go DIRECTLY to step 1. Run `wait-for-pr-update.sh`
+again. The script blocks (zero cost) until the next event.
+
+> **🛑 Do NOT poll, check, or query GitHub between signals.**
+> Every check between `wait-for-pr-update.sh` calls is wasted tokens.
+> The script handles ALL detection — CI results, new comments, merges,
+> pushes. Trust it.
 
 **Do NOT end with `[GOAL_COMPLETE]` unless the PR is merged.**
 **Do NOT end with `[GOAL_BLOCKED]` unless the PR is closed.**
@@ -195,5 +205,7 @@ You MUST NOT:
 - Ignore review comments (address or explain why not)
 - Undraft while CI is failing
 - Spam reviewers (request review only once after CI goes green, not on every push)
+- Poll CI status in a loop (`gh run list`, `gh pr checks`, `sleep && check`) — the blocking script detects CI completion
+- Run `gh run watch` — use `wait-for-pr-update.sh` instead
 - End with `[GOAL_COMPLETE]` unless PR is merged
 - End with `[GOAL_BLOCKED]` unless PR is closed (waiting for review is NOT blocked)

--- a/skills/oss-ci-sweeper/SKILL.md
+++ b/skills/oss-ci-sweeper/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: oss-ci-sweeper
+description: >
+  CI sweeper loop. Monitors CI on watched branches, classifies failures
+  (flake, regression, infra), and proposes minimal fixes as draft PRs.
+  Uses sub-agents for parallel fix and verification with a maker/checker pattern.
+  Reads project config from .oss-ai-helper-rules/.
+guidelines:
+  - ci-sweeper.md: Main CI sweeper orchestrator loop
+  - ci-triage.md: Classify CI failures (flake, regression, infra)
+---

--- a/skills/oss-ci-sweeper/SKILL.md
+++ b/skills/oss-ci-sweeper/SKILL.md
@@ -9,3 +9,12 @@ guidelines:
   - ci-sweeper.md: Main CI sweeper orchestrator loop
   - ci-triage.md: Classify CI failures (flake, regression, infra)
 ---
+
+# IMPORTANT — Read ci-sweeper.md Before Doing Anything
+
+**You MUST read and follow `ci-sweeper.md` step by step.** Do NOT attempt to
+implement the CI sweeper from the description above — the guideline contains
+mandatory blocking scripts that must run before any GitHub API calls.
+
+Start by reading `ci-sweeper.md` now. Step 0 is a blocking precondition that
+you MUST execute before proceeding.

--- a/skills/oss-ci-sweeper/ci-sweeper.md
+++ b/skills/oss-ci-sweeper/ci-sweeper.md
@@ -51,10 +51,16 @@ Main loop (orchestrator)
 Run these commands NOW, before reading any further:
 
 ```bash
-# 1. Pull latest state from the fork
-~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
+# 1. Detect fork repo and state branch from local config
+FORK_REPO=$(git remote get-url origin 2>/dev/null | sed -E 's#.*github.com[:/]##; s#\.git$##')
+STATE_BRANCH=$(python3 -c "import json; print(json.load(open('loop-config.json'))['state_branch'])" 2>/dev/null || echo "")
 
-# 2. BLOCK here until a CI failure is detected
+# 2. Pull latest state from the fork (skip if no config yet — first run)
+if [[ -n "$STATE_BRANCH" ]]; then
+  ~/.claude/scripts/pull-state.sh "$FORK_REPO" "$STATE_BRANCH" .
+fi
+
+# 3. BLOCK here until a CI failure is detected
 #    This command will NOT return for minutes or hours. That is correct.
 #    Do NOT interrupt it. Do NOT set a short timeout. Let it block.
 ~/.claude/scripts/wait-for-ci-failure.sh

--- a/skills/oss-ci-sweeper/ci-sweeper.md
+++ b/skills/oss-ci-sweeper/ci-sweeper.md
@@ -35,37 +35,53 @@ Main loop (orchestrator)
 
 ## Execution Steps
 
-### 0. Pre-flight — Wait for CI Failure
+### 0. MANDATORY — Block Until CI Failure Detected
 
-Run the blocking precondition script. It polls the GitHub Events API using
-ETag-based conditional requests (free on 304 Not Modified) and only returns
-when a CI failure is detected on a watched branch — or when the timeout expires.
+> **🛑 STOP. Do NOT skip this step. Do NOT proceed to step 1.**
+>
+> You MUST run the blocking precondition script FIRST, BEFORE doing anything
+> else. This script polls GitHub using zero-cost ETag requests and BLOCKS
+> until a CI failure is detected on a watched branch. Without it, you burn
+> tokens checking CI that is already green.
+>
+> **If you skip this step and go straight to `gh run list`, you are doing it
+> wrong.** The whole point of this loop is to sleep cheaply and only wake up
+> when CI is red.
 
-This means **zero LLM tokens are consumed while waiting**. The script blocks
-the session, not the model.
-
-**With `/goal` (recommended for Claude Code — immediate reactivity):**
+Run these commands NOW, before reading any further:
 
 ```bash
+# 1. Pull latest state from the fork
 ~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
+
+# 2. BLOCK here until a CI failure is detected
+#    This command will NOT return for minutes or hours. That is correct.
+#    Do NOT interrupt it. Do NOT set a short timeout. Let it block.
 ~/.claude/scripts/wait-for-ci-failure.sh
 ```
 
-No timeout — blocks indefinitely until a CI failure is detected.
+**This command blocks.** It sits in a `while true` loop, polling the GitHub
+Actions API with ETag conditional requests (304 = free, no rate limit hit).
+It will return ONLY when:
+- A CI failure is detected on a watched branch (exit 0 → proceed to step 1)
+- The kill switch is set in state.json (exit 1 → stop, do nothing)
 
-**With `/loop` (recommended for ForgeBot — persistence across restarts):**
+**Expected behavior:** After you run this command, nothing happens for a long
+time. That is correct. The script is sleeping and polling. You are saving
+tokens by not doing anything until CI breaks.
 
+**With ForgeBot `/loop`:** Use `--timeout` matching the loop interval:
 ```bash
-~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
 ~/.claude/scripts/wait-for-ci-failure.sh --timeout 900
 ```
+Exit 1 on timeout = skip this tick, report nothing, exit immediately.
 
-Timeout matches the `/loop` interval. Exit 1 on timeout = skip this tick.
+**Do NOT proceed past this point until `wait-for-ci-failure.sh` returns exit 0.**
 
-> See the `/goal` vs `/loop` comparison in `review-loop.md` step 0.
-
-If the script exits with code 1 (timeout, all green, or kill switch), all
-watched branches are green — **skip this iteration entirely**.
+If it exits with code 1 (timeout, all green, or kill switch):
+- **Output nothing.** Do not say "all branches green" or "no failures."
+- **Do not run `gh run list`.** The script already checked.
+- **Exit immediately.** The loop will fire again later.
 
 If it exits with code 0, proceed:
 

--- a/skills/oss-ci-sweeper/ci-sweeper.md
+++ b/skills/oss-ci-sweeper/ci-sweeper.md
@@ -1,0 +1,301 @@
+---
+name: ci-sweeper
+description: >
+  CI sweeper loop. Monitors CI on watched branches, classifies
+  failures (flake, regression, infra), and proposes minimal fixes as draft PRs.
+  Uses sub-agents for parallel fix and verification with a maker/checker pattern.
+  Tracks state in state.json.
+user-invocable: true
+---
+
+# CI Sweeper Loop
+
+Automated loop that discovers CI failures on watched branches, classifies them,
+and proposes minimal fixes. Uses worktree-isolated sub-agents for fixes and
+independent verifiers before opening draft PRs.
+
+## Architecture
+
+```
+Main loop (orchestrator)
+  +-- Step 0: Pre-flight (ETag check + deterministic state load)
+  |
+  +-- Step 1-3: Discover & classify (inline -- fast, low cost)
+  |
+  +-- Step 4: Fix (sub-agents, parallel, worktree-isolated)
+  |     +-- Implementer agent failure #1 (worktree)
+  |     +-- Implementer agent failure #2 (worktree)
+  |
+  +-- Step 5: Verify (sub-agents, one per fix)
+  |     +-- Verifier agent fix #1  <- checks implementer's work
+  |     +-- Verifier agent fix #2
+  |
+  +-- Step 6-8: Open draft PRs, update state, push (deterministic scripts)
+```
+
+## Execution Steps
+
+### 0. Pre-flight — Wait for CI Failure
+
+Run the blocking precondition script. It polls the GitHub Events API using
+ETag-based conditional requests (free on 304 Not Modified) and only returns
+when a CI failure is detected on a watched branch — or when the timeout expires.
+
+This means **zero LLM tokens are consumed while waiting**. The script blocks
+the session, not the model.
+
+**With `/goal` (recommended for Claude Code — immediate reactivity):**
+
+```bash
+~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
+~/.claude/scripts/wait-for-ci-failure.sh
+```
+
+No timeout — blocks indefinitely until a CI failure is detected.
+
+**With `/loop` (recommended for ForgeBot — persistence across restarts):**
+
+```bash
+~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
+~/.claude/scripts/wait-for-ci-failure.sh --timeout 900
+```
+
+Timeout matches the `/loop` interval. Exit 1 on timeout = skip this tick.
+
+> See the `/goal` vs `/loop` comparison in `review-loop.md` step 0.
+
+If the script exits with code 1 (timeout, all green, or kill switch), all
+watched branches are green — **skip this iteration entirely**.
+
+If it exits with code 0, proceed:
+
+1. Run the ForgeBot init steps (read `init.md`) to detect the project and load config.
+2. Read `loop-config.json` -- load constraints, budget, cadence, watched branches.
+3. Check `state.json` `paused` flag -- if true, exit immediately.
+
+From initialization, you now have:
+- **UPSTREAM_REPO**: the upstream org/repo (from `project-info.md`)
+- **FORK_REPO**: the operator's fork org/repo
+- **OPERATOR_NAME**: for attribution
+- **BUILD_CMD**, **TEST_CMD**, **FORMAT_CMD**: from `project-standards.md`
+- **WATCHED_BRANCHES**, **CI_WORKFLOW**: from `loop-config.json`
+
+### 1. Discover CI Failures
+
+For each watched branch (from `loop-config.json`), get the latest CI run:
+
+```bash
+gh run list --repo $UPSTREAM_REPO --branch $BRANCH \
+  --workflow "$CI_WORKFLOW" --limit 1 \
+  --json databaseId,status,conclusion,headSha,createdAt \
+  --jq '.[0]'
+```
+
+If the latest run is `completed` with `conclusion: success` -> CI is green.
+Log it and move on to the next branch.
+
+If the latest run is `completed` with `conclusion: failure`:
+
+```bash
+# Get failed jobs
+gh run view <RUN_ID> --repo $UPSTREAM_REPO \
+  --json jobs --jq '.jobs[] | select(.conclusion == "failure") | {name, conclusion, steps: [.steps[] | select(.conclusion == "failure") | .name]}'
+```
+
+```bash
+# Download the log for the failed run
+gh run view <RUN_ID> --repo $UPSTREAM_REPO --log-failed 2>/dev/null | tail -500
+```
+
+If the run is still `in_progress` or `queued`, skip this branch.
+
+### 2. Check Against State (Deterministic — No LLM)
+
+Read `state.json` and compare each failure against:
+
+- `active_failures[]` -- same failure (same job name + similar error)?
+  If yes, check attempt count. If attempts >= max (from `loop-config.json`),
+  escalate instead of retrying.
+- `resolved[]` -- was this failure recently resolved but came back? Flag as
+  regression of a regression.
+- `proposed_fixes[]` -- is there already a draft PR for this failure?
+  Check PR status instead of re-attempting.
+
+### 3. Classify Failures
+
+For each new or updated failure, use the `ci-triage.md` skill to classify it as
+flake, regression, or infrastructure issue. The triage skill reads the CI logs,
+checks recent run history, and correlates with commits.
+
+### 4. Fix Regressions (Parallel Sub-agents)
+
+For each actionable regression (max per run from `loop-config.json`), spawn an
+**implementer sub-agent** using the Agent tool with `isolation: "worktree"`.
+
+Each implementer agent prompt must include:
+
+```
+You are fixing a CI failure on $UPSTREAM_REPO.
+
+## Failure Details
+- Branch: <branch>
+- Job: <job-name>
+- Error: <error message, truncated to relevant lines>
+- Likely culprit commit: <sha> "<message>"
+- CI run log (relevant excerpt): <paste relevant log lines>
+
+## Instructions
+
+1. Read the project rules:
+   - Read .oss-ai-helper-rules/project-standards.md (build/test commands)
+   - Read .oss-ai-helper-rules/project-guidelines.md (conventions)
+
+2. Investigate the failure:
+   - Read the culprit commit: git show <sha>
+   - Understand what it changed and why
+   - Read the failing test(s) and the code they exercise
+   - Check git history for context (git log, git blame)
+
+3. Produce the minimal fix:
+   - Change only what is necessary to fix the failure
+   - Do NOT refactor unrelated code
+   - Do NOT disable tests or weaken assertions
+   - Max 5 files changed -- if more are needed, STOP and report
+
+4. Run tests:
+   - Build the affected module: $BUILD_CMD (scoped to module)
+   - Run the specific failing test if identifiable
+   - Report the test result
+
+5. Format the code:
+   - Run: $FORMAT_CMD (scoped to module)
+
+6. Return your findings:
+
+   STATUS: <fixed|needs-escalation|cannot-fix>
+   FIX_SUMMARY: <1-3 sentence description of what you changed and why>
+   FILES_CHANGED:
+   - <path/to/file> -- <what changed>
+   TEST_RESULT: <pass|fail -- command + output snippet>
+   RISK: <low|medium|high>
+
+   If STATUS is needs-escalation or cannot-fix, explain why.
+```
+
+### 5. Verify Fixes (Parallel Sub-agents)
+
+After all implementer agents complete, spawn a **verifier sub-agent** for each
+fix that returned `STATUS: fixed`. Use the `loop-verifier` agent definition.
+
+Each verifier prompt must include:
+
+```
+You are verifying a proposed CI fix for $UPSTREAM_REPO.
+
+## Original Failure
+- Branch: <branch>
+- Job: <job-name>
+- Error: <error summary>
+
+## Proposed Fix
+- Files changed: <list>
+- Summary: <implementer's FIX_SUMMARY>
+
+## Your Job
+
+1. Review the diff in the worktree -- does it address the root cause?
+2. Check git history -- does this fix revert prior intentional work?
+3. Run the tests: $TEST_CMD (scoped to module)
+4. Verify scope -- are only relevant files changed? No drive-by edits?
+5. Check for cheating -- no disabled tests, skipped assertions, commented checks?
+
+Return your verdict:
+
+VERDICT: <APPROVE|REJECT|ESCALATE_HUMAN>
+EVIDENCE:
+- Tests: <command + result>
+- Scope check: <pass/fail + notes>
+- Root cause addressed: <yes/no + reasoning>
+
+If REJECT:
+- Reasons: <numbered, specific>
+- Suggested next step for implementer
+```
+
+### 6. Open Draft PRs
+
+For each fix where the verifier returned `APPROVE`:
+
+1. Create a branch on the operator's fork:
+   ```bash
+   git checkout -b ci-fix/<failure-slug> origin/<branch>
+   git push fork ci-fix/<failure-slug>
+   ```
+
+2. Open a draft PR:
+   ```bash
+   gh pr create --repo $UPSTREAM_REPO \
+     --head $FORK_ORG:ci-fix/<failure-slug> \
+     --base <branch> \
+     --draft \
+     --title "ci: fix <failure-description>" \
+     --body "<summary + CI details + verification + attribution>"
+   ```
+
+### 7. Update State (Deterministic — No LLM)
+
+```bash
+# Record each failure and its outcome
+python3 ~/.claude/scripts/update-state.py state.json reviewed \
+  --pr <DRAFT_PR_NUMBER> --title "<title>" --author "$(git config user.name)" \
+  --verdict COMMENT --notes "CI fix proposed: <summary>"
+
+# Record this run
+python3 ~/.claude/scripts/update-state.py state.json run \
+  --prs-checked <BRANCHES_CHECKED> --reviews-posted <FIXES_PROPOSED> --tokens <T>
+```
+
+### 8. Push State (Deterministic — No LLM)
+
+```bash
+~/.claude/scripts/push-state.sh $FORK_REPO $STATE_BRANCH \
+  state.json loop-run-log.json learnings.json
+```
+
+### 9. Summary
+
+Output a brief summary:
+
+```
+## CI Sweeper Complete
+
+- Branches checked: <list>
+- Failures found: <N> (<M> regressions, <F> flakes, <I> infra)
+- Fixes proposed: <P> draft PRs
+- Escalated: <E> failures
+- Verifier rejection rate: <X>%
+- Next check in: <cadence>
+```
+
+## Constraints
+
+You MUST:
+- Read state.json before checking CI to track across runs
+- Early-exit in < 5k tokens if all branches are green
+- Run loop-guard before each fix attempt
+- Spawn implementer agents with worktree isolation
+- Run verifier agent before opening any PR
+- Open all PRs as draft on the operator's fork
+- Include AI attribution in all PRs
+- Update state.json after every run (via update-state.py)
+- Respect the per-run failure limit from loop-config.json
+- Use build/test commands from project-standards.md, never hardcode
+
+You MUST NOT:
+- Merge, close, or label any PR
+- Push to the upstream repo directly
+- Fix flaky tests (log and skip)
+- Act on infrastructure failures (escalate)
+- Disable tests or weaken assertions to go green
+- Change more than 5 files per fix (or custom limit from loop-config.json)
+- Attempt more than the max fix attempts for the same failure

--- a/skills/oss-ci-sweeper/ci-sweeper.md
+++ b/skills/oss-ci-sweeper/ci-sweeper.md
@@ -73,6 +73,12 @@ fi
 ~/.claude/scripts/wait-for-ci-failure.sh
 ```
 
+> **🛑 WHILE THIS SCRIPT IS RUNNING, DO NOTHING ELSE.**
+>
+> Do NOT run any other bash commands in parallel. Do NOT check CI status.
+> Do NOT run `gh run list`. The script IS the check. Wait for it to exit,
+> then read its output.
+
 **This command blocks.** It sits in a `while true` loop, polling the GitHub
 Actions API with ETag conditional requests (304 = free, no rate limit hit).
 It will return ONLY when:

--- a/skills/oss-ci-sweeper/ci-sweeper.md
+++ b/skills/oss-ci-sweeper/ci-sweeper.md
@@ -73,11 +73,11 @@ fi
 ~/.claude/scripts/wait-for-ci-failure.sh
 ```
 
-> **🛑 WHILE THIS SCRIPT IS RUNNING, DO NOTHING ELSE.**
+> **🛑 Block waiting for this script to finish. Do NOT run any other command.**
 >
-> Do NOT run any other bash commands in parallel. Do NOT check CI status.
-> Do NOT run `gh run list`. The script IS the check. Wait for it to exit,
-> then read its output.
+> This script will run for minutes or hours. That is expected.
+> Do NOT run any bash command while it is running — not `gh`, not `cat`,
+> not `date`, nothing. Just wait. When it exits, read the output and act.
 
 **This command blocks.** It sits in a `while true` loop, polling the GitHub
 Actions API with ETag conditional requests (304 = free, no rate limit hit).

--- a/skills/oss-ci-sweeper/ci-sweeper.md
+++ b/skills/oss-ci-sweeper/ci-sweeper.md
@@ -85,7 +85,7 @@ tokens by not doing anything until CI breaks.
 
 **With ForgeBot `/loop`:** Use `--timeout` matching the loop interval:
 ```bash
-~/.claude/scripts/wait-for-ci-failure.sh --timeout 900
+~/.claude/scripts/wait-for-ci-failure.sh --timeout 3600
 ```
 Exit 1 on timeout = skip this tick, report nothing, exit immediately.
 

--- a/skills/oss-ci-sweeper/ci-sweeper.md
+++ b/skills/oss-ci-sweeper/ci-sweeper.md
@@ -52,7 +52,14 @@ Run these commands NOW, before reading any further:
 
 ```bash
 # 1. Detect fork repo and state branch from local config
-FORK_REPO=$(git remote get-url origin 2>/dev/null | sed -E 's#.*github.com[:/]##; s#\.git$##')
+#    State is stored on the FORK, not upstream — use the 'fork' remote if it exists
+FORK_REPO=$(git remote get-url fork 2>/dev/null | sed -E 's#.*github.com[:/]##; s#\.git$##')
+if [[ -z "$FORK_REPO" ]]; then
+  for remote in gnodet origin; do
+    FORK_REPO=$(git remote get-url "$remote" 2>/dev/null | sed -E 's#.*github.com[:/]##; s#\.git$##')
+    [[ -n "$FORK_REPO" ]] && break
+  done
+fi
 STATE_BRANCH=$(python3 -c "import json; print(json.load(open('loop-config.json'))['state_branch'])" 2>/dev/null || echo "")
 
 # 2. Pull latest state from the fork (skip if no config yet — first run)

--- a/skills/oss-ci-sweeper/ci-triage.md
+++ b/skills/oss-ci-sweeper/ci-triage.md
@@ -1,0 +1,119 @@
+---
+name: ci-triage
+description: >
+  Classify a CI failure as flake, regression, or infrastructure issue.
+  Parse CI logs, identify the failing job/step, correlate with recent commits,
+  and recommend an action (fix, skip, escalate).
+user-invocable: true
+---
+
+# CI Triage Skill
+
+Classify a single CI failure and recommend an action.
+
+## Inputs
+
+- CI run ID or URL
+- Branch name
+- Failing job name (if known)
+- Error log excerpt (if available)
+- **UPSTREAM_REPO** (from init)
+
+## Process
+
+### 1. Fetch Failure Details
+
+```bash
+# Get failed jobs from the run
+gh run view <RUN_ID> --repo $UPSTREAM_REPO \
+  --json jobs --jq '.jobs[] | select(.conclusion == "failure") | {name, conclusion}'
+
+# Get the log for failed jobs
+gh run view <RUN_ID> --repo $UPSTREAM_REPO --log-failed 2>/dev/null | tail -500
+```
+
+### 2. Parse the Error
+
+Extract:
+- **Test class and method** (if test failure): from `Tests run:` / `Failed:` lines
+- **Error type**: `AssertionError`, `TimeoutException`, `CompilationError`, etc.
+- **Stack trace**: first 10 lines of the relevant stack trace
+- **Module**: which build module failed
+
+### 3. Classify
+
+**Flake indicators** (classify as `flake`):
+- Test has `@Flaky` or `@DisabledOnCI` annotation
+- Error is timing-related: `TimeoutException`, `ConnectException`, `BindException`
+- Same test alternates pass/fail across recent runs
+- Error mentions port conflicts, connection refused, socket timeout
+- Test is in an integration test module with external service dependency
+
+**Infrastructure indicators** (classify as `infra`):
+- `OutOfMemoryError` in the runner (not in the test)
+- Docker/container registry errors: `rate limit`, `manifest unknown`, `toomanyrequests`
+- Dependency download failures: `Could not transfer artifact`, `Could not resolve`
+- CI service errors: `RUNNER_FAILED`, `TIMEOUT`
+- Disk full: `No space left on device`
+
+**Regression indicators** (classify as `regression`):
+- Compilation error in recently changed code
+- New test failure not seen in prior 10 runs
+- `AssertionError` with clear logic bug (not timing)
+- Failure correlates with a commit that touched the failing module
+
+### 4. Find Culprit (for regressions)
+
+```bash
+# Last green SHA
+LAST_GREEN=$(gh run list --repo $UPSTREAM_REPO --branch <branch> \
+  --workflow "$CI_WORKFLOW" --limit 20 \
+  --json headSha,conclusion \
+  --jq '[.[] | select(.conclusion == "success")][0].headSha')
+
+# Commits between last green and failing SHA
+git log --oneline $LAST_GREEN..<FAILING_SHA> -- <module-path>
+```
+
+For each candidate commit, check if it touched files related to the failure:
+```bash
+git show --stat <commit-sha> | grep -i <failing-class-or-module>
+```
+
+### 5. Recommend Action
+
+| Classification | Action | Details |
+|---------------|--------|---------|
+| `flake` | `skip` | Log in STATE.md, do not attempt fix |
+| `infra` | `escalate` | Log in STATE.md Escalated section |
+| `regression` (< 5 files scope) | `fix` | Spawn implementer sub-agent |
+| `regression` (> 5 files scope) | `escalate` | Too large for automated fix |
+| `regression` (3+ prior attempts) | `escalate` | Circuit breaker tripped |
+
+## Output
+
+```markdown
+## CI Triage: <job-name>
+
+- **Branch:** <branch>
+- **Run:** <run-id>
+- **SHA:** <sha>
+- **Classification:** flake | regression | infra
+- **Confidence:** high | medium | low
+- **Error:** <one-line summary>
+- **Module:** <build-module>
+- **Failing test:** <class#method> (if applicable)
+- **Culprit commit:** <sha> "<message>" (if regression)
+- **Action:** fix | skip | escalate
+- **Reason:** <why this classification and action>
+```
+
+## Rules
+
+- Default to `escalate` when uncertain -- false negatives (missing a real issue)
+  are worse than false positives (escalating a flake).
+- Never classify a compilation error as a flake.
+- Never classify a new test failure (not seen in last 10 runs) as a flake
+  without strong evidence.
+- If the same failure appears on multiple branches, classify once and apply
+  the classification to all affected branches.

--- a/skills/oss-ci/SKILL.md
+++ b/skills/oss-ci/SKILL.md
@@ -24,3 +24,4 @@ After initialization, read and follow the appropriate guideline file based on th
 | Fix SonarCloud issues for a rule | `fix-sonarcloud.md` |
 | Fix a GitHub security or quality alert | `fix-github-alert.md` |
 | Apply a quick fix (CI, docs, deps, etc.) without a tracked issue | `quick-fix.md` |
+| Produce the smallest possible code change for a CI failure | `minimal-fix.md` |

--- a/skills/oss-ci/minimal-fix.md
+++ b/skills/oss-ci/minimal-fix.md
@@ -1,0 +1,79 @@
+---
+name: minimal-fix
+description: >
+  Produce the smallest possible code change that fixes a specific, well-scoped
+  CI failure. Use only when the fix target is explicit. Never refactor unrelated code.
+  Reads build/test commands from project-standards.md.
+user-invocable: true
+---
+
+# Minimal Fix Skill
+
+You fix **one specific CI failure** with the **smallest diff** that could work.
+
+## Inputs
+
+- Exact failure message and stack trace
+- Failing test class and method (if test failure)
+- Culprit commit SHA (if identified by triage)
+- Module path
+- Path denylist (from loop-constraints.md)
+- **BUILD_CMD**, **TEST_CMD**, **FORMAT_CMD** (from project-standards.md via init)
+
+## Process
+
+1. **Understand the failure**: Read the error, the failing test, and the code it exercises.
+2. **Read the culprit commit**: `git show <sha>` -- understand what changed and why.
+3. **Check git history**: `git log --oneline -10 <failing-file>` and `git blame` for context.
+4. **Identify the minimal root cause**: Not symptoms in distant files, but the actual bug.
+5. **Apply the fix**: Change only what is required. No drive-by refactors.
+6. **Format the code**:
+   Run `$FORMAT_CMD` scoped to the module. If the project uses Maven:
+   ```bash
+   cd <module> && mvn formatter:format impsort:sort -B
+   ```
+   For other build tools, use the format command from project-standards.md.
+7. **Run tests**:
+   Run `$TEST_CMD` scoped to the module. If the project uses Maven:
+   ```bash
+   mvn clean install -B -pl <module> -am
+   ```
+   Or if the specific test is known:
+   ```bash
+   mvn test -B -pl <module> -Dtest=<TestClass>#<method>
+   ```
+   For other build tools, use the test command from project-standards.md.
+8. **Summarize**: What changed, why, what you ran.
+
+## Output
+
+```markdown
+## Minimal Fix Proposal
+
+- **Target:** <CI failure / test name / error>
+- **Root cause:** <one-sentence explanation>
+- **Files changed:**
+  - <path/to/file> -- <what changed>
+- **Diff summary:** <1-3 bullets>
+- **Tests run:** <command + result>
+- **Risk:** low | medium
+  - If medium, explain why and recommend human review
+```
+
+## Rules
+
+- If fix requires > 5 files -> **stop and escalate**. Report:
+  ```
+  STATUS: needs-escalation
+  REASON: Fix scope exceeds 5 files (<N> files affected). Needs human design decision.
+  ```
+- If path is on denylist (from loop-constraints.md) -> **stop and escalate**
+- If fix would revert a prior intentional commit -> **stop and explain**
+  (check with `git log` and linked issue/PR)
+- Do NOT disable tests or weaken assertions to go green
+- Do NOT add `@Disabled`, `@Ignore`, or `assumeTrue(false)` to make tests pass
+- Do NOT mark yourself "done" -- the verifier decides
+- Do NOT change unrelated code, even if you notice issues
+- Do NOT bump dependency versions without explicit approval
+- Always follow the project's code conventions (from .oss-ai-helper-rules/)
+- Always use Awaitility instead of Thread.sleep() in test code (Java projects)

--- a/skills/oss-issue-loop/SKILL.md
+++ b/skills/oss-issue-loop/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: oss-issue-loop
+description: >
+  Issue triage loop. Monitors a project for open issues, triages them,
+  and spawns ForgeBot tasks to fix and babysit each one.
+guidelines:
+  - issue-loop.md: Main issue triage and dispatch orchestrator
+---

--- a/skills/oss-issue-loop/issue-loop.md
+++ b/skills/oss-issue-loop/issue-loop.md
@@ -1,0 +1,180 @@
+---
+name: issue-loop
+description: >
+  Issue triage loop. Monitors for open issues, triages deterministically,
+  spawns ForgeBot tasks to fix selected issues and babysit the resulting PRs.
+user-invocable: true
+---
+
+# Issue Loop
+
+Automated loop that discovers open issues, triages them, and dispatches
+ForgeBot tasks to fix the most actionable ones. Each spawned task fixes the
+issue AND babysits the resulting PR until merge.
+
+## Usage
+
+```
+/goal Monitor and fix issues on this project
+```
+
+Or with ForgeBot (persistent):
+
+```
+/loop 5m --session-ttl 1h issue-loop
+```
+
+## Architecture
+
+```
+Issue Loop (orchestrator)
+  +-- Step 0: Wait for issue activity (ETag blocking)
+  +-- Step 1: Init (detect project, load config)
+  +-- Step 2: Triage issues (deterministic script)
+  +-- Step 3: For each actionable issue:
+  |     +-- forge-task <repo> "Fix issue #N, then babysit the PR"
+  +-- Step 4: Update state (mark issues as handled)
+  +-- Step 5: Push state
+  +-- Loop back to step 0
+```
+
+The orchestrator does NOT fix issues itself — it triages and dispatches.
+Each ForgeBot task runs independently with its own Claude Code session
+and worktree.
+
+## Execution Steps
+
+### 0. Pre-flight — Wait for Issue Activity
+
+Run the blocking precondition script. It polls GitHub Events API using
+ETag-based conditional requests until issue activity is detected.
+
+**With `/goal` (recommended):**
+
+```bash
+~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
+~/.claude/scripts/wait-for-pr-work.sh state.json
+```
+
+The `wait-for-pr-work.sh` script detects general repo activity, which
+includes issue creation. For issue-specific polling, the script exits
+on any repo event, and step 2 does the actual issue filtering.
+
+**With `/loop` (ForgeBot):**
+
+```bash
+~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
+~/.claude/scripts/wait-for-pr-work.sh --timeout 300 state.json
+```
+
+If exit 1 (timeout), skip this iteration.
+
+### 1. Initialize
+
+Run the ForgeBot init steps (read `init.md`):
+- Detect project from git remote
+- Load project rules from `.oss-ai-helper-rules/`
+- Pull latest oss-helper (`git pull`)
+- Load state from the state branch
+
+From initialization, you have:
+- **UPSTREAM_REPO**: the upstream org/repo
+- **FORK_REPO**: the operator's fork
+- **MAX_ISSUES_PER_RUN**: from `loop-config.json` (default: 2)
+
+### 2. Triage Issues (Deterministic)
+
+Run the triage script — no LLM needed:
+
+```bash
+python3 ~/.claude/scripts/triage-issues.py $UPSTREAM_REPO state.json \
+  --max $MAX_ISSUES_PER_RUN \
+  --labels bug,help-wanted \
+  --format json
+```
+
+The script:
+- Fetches open issues from GitHub
+- Filters out: bots, already-handled, already-skipped, assigned issues
+- Prioritizes: bugs > help-wanted > old issues
+- Returns JSON array of actionable issues
+
+If exit 1 (no actionable issues), go back to step 0.
+
+### 3. Dispatch Tasks
+
+For each actionable issue, spawn a ForgeBot task:
+
+```bash
+forge-task $UPSTREAM_REPO "Fix issue #<NUMBER>: <TITLE>
+
+Read the issue description and comments:
+  gh issue view <NUMBER> --repo $UPSTREAM_REPO
+
+Then:
+1. Follow /oss-fix-issue to implement the fix
+2. Create a PR with the fix
+3. Follow /babysit-pr to monitor CI, address reviews, until the PR is merged
+
+Do NOT end until the PR is merged or you are blocked."
+```
+
+**Important:**
+- Spawn at most `MAX_ISSUES_PER_RUN` tasks per iteration (default: 2)
+- Each task gets its own worktree and session — fully isolated
+- The babysit phase handles CI fixes, undraft, review addressing
+- Do NOT wait for tasks to complete — dispatch and move on
+
+### 4. Update State
+
+Mark dispatched issues as handled:
+
+```bash
+for issue_number in <dispatched issues>; do
+  python3 ~/.claude/scripts/update-state.py state.json handled-issue \
+    --issue $issue_number \
+    --notes "Dispatched to ForgeBot task"
+done
+```
+
+### 5. Push State
+
+```bash
+~/.claude/scripts/push-state.sh $FORK_REPO $STATE_BRANCH .
+```
+
+### 6. Loop Back
+
+Go back to step 0. The blocking script waits for the next batch of issues.
+
+**Do NOT end with `[GOAL_COMPLETE]` — this loop runs indefinitely.**
+Use `[GOAL_BLOCKED]` only if there's an unrecoverable error.
+
+## Configuration
+
+In `loop-config.json`:
+
+```json
+{
+  "max_issues_per_run": 2,
+  "issue_labels": ["bug", "help-wanted"],
+  "skip_labels": ["dependencies", "documentation", "wontfix"],
+  "issue_tracker": "github"
+}
+```
+
+## Constraints
+
+You MUST:
+- Use the deterministic triage script (no LLM for issue selection)
+- Dispatch tasks via `forge-task` (parallel, isolated worktrees)
+- Include both `/oss-fix-issue` and `/babysit-pr` in the task prompt
+- Update state after dispatching to avoid re-dispatching
+- Respect the per-run issue limit
+
+You MUST NOT:
+- Fix issues directly in the orchestrator (dispatch only)
+- Dispatch issues that are already assigned to someone
+- Dispatch more than `max_issues_per_run` per iteration
+- Wait for dispatched tasks to complete (fire and forget)
+- Close or modify issues from the orchestrator

--- a/skills/oss-issue-loop/issue-loop.md
+++ b/skills/oss-issue-loop/issue-loop.md
@@ -44,30 +44,39 @@ and worktree.
 
 ## Execution Steps
 
-### 0. Pre-flight — Wait for Issue Activity
+### 0. MANDATORY — Wait for Issue Activity
 
-Run the blocking precondition script. It polls GitHub Events API using
-ETag-based conditional requests until issue activity is detected.
+> **🛑 STOP. Do NOT skip this step. Do NOT proceed to step 1.**
+>
+> You MUST run the blocking precondition script FIRST. It polls GitHub using
+> zero-cost ETag requests and BLOCKS until repo activity is detected.
 
-**With `/goal` (recommended):**
-
-```bash
-~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
-~/.claude/scripts/wait-for-pr-work.sh state.json
-```
-
-The `wait-for-pr-work.sh` script detects general repo activity, which
-includes issue creation. For issue-specific polling, the script exits
-on any repo event, and step 2 does the actual issue filtering.
-
-**With `/loop` (ForgeBot):**
+Run these commands NOW, before reading any further:
 
 ```bash
-~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
-~/.claude/scripts/wait-for-pr-work.sh --timeout 300 state.json
+# 1. Detect fork repo and state branch from local config
+FORK_REPO=$(git remote get-url fork 2>/dev/null | sed -E 's#.*github.com[:/]##; s#\.git$##')
+if [[ -z "$FORK_REPO" ]]; then
+  for remote in gnodet origin; do
+    FORK_REPO=$(git remote get-url "$remote" 2>/dev/null | sed -E 's#.*github.com[:/]##; s#\.git$##')
+    [[ -n "$FORK_REPO" ]] && break
+  done
+fi
+STATE_BRANCH=$(python3 -c "import json; print(json.load(open('loop-config.json'))['state_branch'])" 2>/dev/null || echo "")
+
+# 2. Pull latest state from the fork
+if [[ -n "$STATE_BRANCH" ]]; then
+  ~/.claude/scripts/pull-state.sh "$FORK_REPO" "$STATE_BRANCH" .
+fi
+
+# 3. BLOCK here until repo activity is detected
+~/.claude/scripts/wait-for-pr-work.sh --timeout 3600 state.json
 ```
 
-If exit 1 (timeout), skip this iteration.
+**Do NOT proceed past this point until the script returns exit 0.**
+
+If it exits with code 1:
+- **Output nothing.** Exit immediately.
 
 ### 1. Initialize
 

--- a/skills/oss-loop-core/SKILL.md
+++ b/skills/oss-loop-core/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: oss-loop-core
+description: >
+  Shared loop infrastructure for ForgeBot: circuit breaker (loop-guard),
+  token budget enforcement (loop-budget), and safety constraints (loop-constraints).
+  These skills are used by all ForgeBot loops (ci-sweeper, review-loop).
+guidelines:
+  - loop-guard.md: Circuit breaker — prevents burning tokens on unsolvable problems
+  - loop-budget.md: Token budget enforcement — daily caps and early exit
+  - loop-constraints.md: Safety rules enforcer — reads and applies binding constraints
+  - loop-init.md: Initialize loop config files for a new project
+  - self-update.md: Update ForgeBot skills to latest version via git pull
+---

--- a/skills/oss-loop-core/loop-budget.md
+++ b/skills/oss-loop-core/loop-budget.md
@@ -1,0 +1,35 @@
+---
+name: loop-budget
+description: >
+  Check token budget and run-log spend before and after a loop run.
+  Enforces early exit when over budget or when there is no work to do.
+user-invocable: true
+---
+
+# Loop Budget Guard
+
+Run at the **start** and **end** of every loop iteration.
+
+## Start of Run
+
+1. Read `loop-config.json` for daily caps (`budget.max_tokens_per_day`, `budget.max_runs_per_day`).
+2. Read `loop-run-log.json` — sum `tokens_estimate` for entries in the last 24h.
+3. If spend >= 80% of daily cap -> **report-only mode** (triage but no action agents).
+4. If spend >= 100% or `state.json` has `paused: true` -> **exit immediately**.
+5. If there is no work to do (CI green, no PRs to review) -> **exit in < 5k tokens**
+   (do not spawn sub-agents when there is nothing actionable).
+
+## End of Run
+
+Record the run via script:
+
+```bash
+python3 ~/.claude/scripts/update-state.py state.json run \
+  --prs-checked <N> --reviews-posted <M> --tokens <T>
+```
+
+## Rules
+
+- Never exceed `budget.max_subagents_per_run` from `loop-config.json`.
+- Early-exit when there is no actionable work — do not run the full pipeline.
+- All budget/limit values come from `loop-config.json` (JSON, not markdown).

--- a/skills/oss-loop-core/loop-constraints.md
+++ b/skills/oss-loop-core/loop-constraints.md
@@ -1,0 +1,46 @@
+---
+name: loop-constraints
+description: >
+  Read constraints from loop-config.json at the start of every run and enforce
+  every rule. This skill runs BEFORE triage or any action skill. Constraints are binding.
+user-invocable: true
+---
+
+# Loop Constraints Enforcer
+
+You are the guardrail. Before any other work begins, you MUST:
+
+1. Read `loop-config.json` — the `constraints` object contains all binding rules.
+2. Load every constraint into your working memory.
+3. Check `state.json` `paused` flag -> if true, exit immediately.
+4. Apply these rules to EVERY action that follows.
+
+## How to Enforce
+
+- Before pushing: check `constraints.never_push`, `constraints.always_fork`, `constraints.always_draft`.
+- Before editing a file: check protected path patterns. If a path matches a denylist, escalate.
+- Before proposing a fix: check `constraints.always_verify`. Run tests. One fix per PR.
+- Before opening a PR: verify it's on the operator's fork, is draft, has attribution.
+- Before posting a review: verify it went through the verifier (`constraints.always_verify`).
+
+## Output at Start of Run
+
+Always begin with a one-line confirmation:
+
+```
+Constraints loaded from loop-config.json: N rules active.
+```
+
+If no `loop-config.json` exists, say so and proceed with default safety rules.
+
+## Default Constraints (when no config file exists)
+
+If `loop-config.json` is absent, enforce these minimums:
+- Never edit `.env`, `.env.*`, `auth/`, `security/`, `secrets/`, `credentials/`
+- Never auto-merge any PR
+- Never disable tests
+- Escalate after 3 failed attempts
+- Always open PRs as draft
+- Always push to operator's fork, never upstream
+- Always include AI attribution in all PRs and reviews
+- Never close or label issues/PRs

--- a/skills/oss-loop-core/loop-guard.md
+++ b/skills/oss-loop-core/loop-guard.md
@@ -1,0 +1,92 @@
+---
+name: loop-guard
+description: >
+  Circuit breaker for ForgeBot loops. Before each fix/action attempt, check
+  loop-ledger.json; if the same failure has been attempted too many times
+  or token budget is exceeded, escalate to a human instead of retrying.
+user-invocable: true
+---
+
+# Loop Guard (Circuit Breaker)
+
+Prevents any ForgeBot loop from burning tokens on a problem it cannot solve.
+Wraps every fix/action attempt with a deterministic circuit-breaker check.
+
+## The Ledger
+
+`loop-ledger.json` records the loop's goal and one entry per attempt:
+
+```json
+{
+  "goal": "<goal from LOOP.md>",
+  "pattern": "<ci-sweeper|review-loop>",
+  "level": "L2",
+  "attempts": [
+    {
+      "iteration": 1,
+      "failure": "<identifier — test name, PR number, etc.>",
+      "action": "<what was tried>",
+      "outcome": "failure",
+      "error": "AssertionError: expected 200 got 500",
+      "tokensUsed": 180000,
+      "timestamp": "2026-07-09T10:00:00Z"
+    }
+  ]
+}
+```
+
+`outcome` is `success | failure | noop`. Always include `error` on failures.
+
+## Before Each Action Attempt
+
+1. Read `loop-ledger.json`.
+2. Count attempts for the **same target** (match by identifier — job name + error signature for CI, PR number for reviews).
+3. Check against thresholds (defaults — can be overridden in `loop-budget.md`):
+   - **Stagnation:** same error message 3x in a row -> ESCALATE
+   - **No progress:** 5 consecutive failures (any target) -> ESCALATE
+   - **Iteration cap:** 10 total attempts across all targets -> ESCALATE
+   - **Token budget:** sum of `tokensUsed` exceeds daily cap -> ESCALATE
+4. Return the decision:
+
+```
+LOOP_GUARD: CONTINUE | ESCALATE
+
+If ESCALATE:
+  REASON: <stagnation | no-progress | iteration-cap | token-budget>
+  DETAILS: <specific counts and thresholds>
+  SUGGESTION: <what the human should look at>
+```
+
+## After Each Action Attempt
+
+Append the attempt to `loop-ledger.json`:
+
+```json
+{
+  "iteration": <N>,
+  "failure": "<target identifier>",
+  "action": "<what was tried>",
+  "outcome": "<success|failure|noop>",
+  "error": "<error message if failure>",
+  "tokensUsed": <estimated tokens>,
+  "timestamp": "<ISO8601>"
+}
+```
+
+## On Escalate
+
+1. Write the escalation into STATE.md "Escalated (human required)" section:
+   ```
+   - **<target>**: <N> attempts failed. Last error: <error>.
+     Recommendation: <suggestion for human>.
+   ```
+2. Exit the action loop for this target. Do NOT retry.
+3. Continue processing other targets if within limits.
+
+## Rules
+
+- Never widen thresholds just to keep looping — escalation is a feature.
+- Never edit the ledger to hide a repeated error.
+- A verifier rejection counts as a `failure` — log it.
+- A flake classification counts as `noop` — log it but don't count toward failure caps.
+- Defaults: 3x same error, 5 consecutive failures, 10 iterations total.

--- a/skills/oss-loop-core/loop-init.md
+++ b/skills/oss-loop-core/loop-init.md
@@ -1,0 +1,111 @@
+---
+name: loop-init
+description: >
+  Initialize ForgeBot loop configuration for a project. Uses
+  init-state-branch.sh to create JSON state files on a dedicated branch.
+user-invocable: true
+---
+
+# Loop Initialization
+
+Sets up the loop configuration for a ForgeBot loop on the current project.
+
+## Prerequisites
+
+- Project must have `.oss-ai-helper-rules/` with project-info, project-standards, and project-guidelines.
+- If not present, suggest running `/oss-create-rules` first.
+
+## Process
+
+### 1. Run ForgeBot Init
+
+Follow the initialization steps in `init.md` to detect the project and load rules.
+
+### 2. Ask Which Loop(s)
+
+Ask the user which loop(s) to set up:
+
+1. **CI Sweeper** — monitors CI, classifies failures, proposes fixes as draft PRs
+2. **PR Review Loop** — reviews open PRs, posts verified findings
+3. **Both**
+
+### 3. Ask for Configuration
+
+For each selected loop, ask:
+
+**CI Sweeper:**
+- Watched branches (default: `main` + latest release branch if detectable)
+- Cadence (default: 15 minutes)
+- Max fix attempts per failure (default: 3)
+- Max failures per run (default: 2)
+- Max files per fix (default: 5)
+- CI workflow name(s) to monitor (detect from `.github/workflows/`)
+
+**PR Review Loop:**
+- Cadence (default: 1 hour)
+- Max PRs per run (default: 3)
+- Review level: L1 (comment only) or L2 (approve/request changes)
+- Human gates (e.g. PRs > N lines, security-sensitive paths)
+
+**Shared:**
+- Daily token budget (default: 10M)
+- State branch name (default: `ci-sweeper-state` or `pr-review-loop-state`)
+
+### 4. Detect CI Workflows
+
+For CI Sweeper, auto-detect available CI workflows:
+
+```bash
+ls <repo-root>/.github/workflows/ 2>/dev/null
+grep -l 'push:' <repo-root>/.github/workflows/*.yml | head -5
+```
+
+### 5. Create State Branch (Deterministic — No LLM)
+
+Run the initialization script:
+
+```bash
+~/.claude/scripts/init-state-branch.sh <fork-repo> <state-branch> "<project-name>" <loop-type>
+```
+
+This script:
+1. Creates the state branch on the fork via GitHub API
+2. Pushes initial JSON files: `state.json`, `loop-config.json`, `loop-run-log.json`, `learnings.json`
+3. No git checkout needed — uses API exclusively
+
+The generated `loop-config.json` contains all configuration in one file:
+cadence, budget, constraints, watched branches (for ci-sweeper), and operator identity.
+
+To customize the generated config after initialization:
+
+```bash
+# Pull, edit, push
+~/.claude/scripts/pull-state.sh <fork-repo> <state-branch> .
+# Edit loop-config.json as needed
+~/.claude/scripts/push-state.sh <fork-repo> <state-branch> loop-config.json
+```
+
+### 6. Summary
+
+Tell the user:
+
+```
+ForgeBot <loop-type> initialized for <project>.
+
+State branch: <state-branch> on <fork-repo>
+
+Files created:
+  - state.json         — reviewed PRs, failures, queue (JSON)
+  - loop-config.json   — cadence, budget, constraints (JSON)
+  - loop-run-log.json  — run history (JSON)
+  - learnings.json     — review learnings for self-improvement (JSON)
+
+To start the loop:
+  /loop <cadence> /oss-<loop-type>
+
+To pause:
+  python3 ~/.claude/scripts/update-state.py state.json pause
+
+To resume:
+  python3 ~/.claude/scripts/update-state.py state.json unpause
+```

--- a/skills/oss-loop-core/self-update.md
+++ b/skills/oss-loop-core/self-update.md
@@ -1,0 +1,86 @@
+---
+name: self-update
+description: >
+  Update oss-helper to the latest version via git pull.
+user-invocable: true
+---
+
+# Self-Update
+
+Update oss-helper to the latest version from the remote repository.
+
+## Instructions
+
+### 1. Locate Repository
+
+Find the oss-helper clone:
+
+```bash
+FORGEBOT_SKILLS_DIR=""
+for dir in ~/.oss-helper "$HOME/.claude/oss-helper"; do
+  if [[ -d "$dir/.git" ]] || { [[ -L "$dir" ]] && [[ -d "$(readlink -f "$dir" 2>/dev/null)/.git" ]]; }; then
+    FORGEBOT_SKILLS_DIR="$dir"
+    break
+  fi
+done
+```
+
+If `FORGEBOT_SKILLS_DIR` is empty, the skills were not installed via git clone.
+Inform the user and stop:
+
+> ForgeBot skills were not installed via git clone. Please reinstall:
+> ```
+> git clone https://gitea.gnodet.fr/gnodet/oss-helper.git ~/.oss-helper
+> ~/.oss-helper/install.sh
+> ```
+
+### 2. Fetch and Show Available Updates
+
+```bash
+git -C "$FORGEBOT_SKILLS_DIR" fetch --quiet 2>/dev/null
+UPDATES=$(git -C "$FORGEBOT_SKILLS_DIR" log HEAD..origin/main --oneline 2>/dev/null)
+```
+
+If `$UPDATES` is empty, report: "ForgeBot skills are already up to date."
+
+Otherwise, show the incoming changes and pull:
+
+```bash
+echo "Updates available:"
+echo "$UPDATES"
+git -C "$FORGEBOT_SKILLS_DIR" pull --quiet
+```
+
+### 3. Update Installed Skills
+
+For symlink-based installs (Claude), no further action is needed — symlinks
+already point to the updated files.
+
+For copy-based installs, re-run the installer:
+
+```bash
+"$FORGEBOT_SKILLS_DIR/install.sh"
+```
+
+### 4. Reset Update Check Throttle
+
+```bash
+touch "$FORGEBOT_SKILLS_DIR/.last-update-check"
+```
+
+### 5. Report Results
+
+```
+ForgeBot skills updated successfully.
+
+Changes applied:
+<list of commits from $UPDATES>
+
+Skills are current as of: <timestamp>
+```
+
+If the pull failed (e.g. local modifications), report the error and suggest:
+
+```
+git -C ~/.oss-helper stash && git -C ~/.oss-helper pull && git -C ~/.oss-helper stash pop
+```

--- a/skills/oss-review-loop/SKILL.md
+++ b/skills/oss-review-loop/SKILL.md
@@ -10,3 +10,12 @@ guidelines:
   - learnings.md: Review learnings system — persistent feedback loop for self-improvement
   - consolidate-learnings.md: Graduate high-confidence learnings into ast-grep rules
 ---
+
+# IMPORTANT — Read review-loop.md Before Doing Anything
+
+**You MUST read and follow `review-loop.md` step by step.** Do NOT attempt to
+implement the review loop from the description above — the guideline contains
+mandatory blocking scripts that must run before any GitHub API calls.
+
+Start by reading `review-loop.md` now. Step 0 is a blocking precondition that
+you MUST execute before proceeding.

--- a/skills/oss-review-loop/SKILL.md
+++ b/skills/oss-review-loop/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: oss-review-loop
+description: >
+  PR review loop. Lists open PRs, filters already-reviewed ones,
+  triages new/updated PRs, and reviews them using sub-agents with
+  a maker/checker pattern. Reads project config from .oss-ai-helper-rules/.
+guidelines:
+  - review-loop.md: Main PR review orchestrator loop
+  - pr-review-triage.md: Quick triage per PR (CI status, review state)
+  - learnings.md: Review learnings system — persistent feedback loop for self-improvement
+  - consolidate-learnings.md: Graduate high-confidence learnings into ast-grep rules
+---

--- a/skills/oss-review-loop/consolidate-learnings.md
+++ b/skills/oss-review-loop/consolidate-learnings.md
@@ -1,0 +1,151 @@
+---
+name: consolidate-learnings
+description: >
+  Graduate high-confidence review learnings into ast-grep rules or
+  suppress patterns.
+user-invocable: true
+---
+
+# Learnings Consolidation
+
+Periodically extract high-confidence learnings into ast-grep rules or skill
+improvements. This is the mechanism by which the review loop becomes
+self-improving — validated patterns graduate from soft LLM guidance into
+deterministic structural checks.
+
+## Triggers
+
+Run consolidation when any of these conditions are met:
+
+1. A learning reaches `confidence >= 0.9` AND `occurrences >= 5`
+2. The `learnings.json` file exceeds 50 entries
+3. Monthly maintenance (at the start of each month's first loop run)
+
+Consolidation can be triggered manually via `/consolidate-learnings`
+or runs automatically within the review loop when triggers are met.
+
+## Process
+
+### 1. Load and Classify Learnings
+
+Load `learnings.json` from the state branch. Classify learnings into
+consolidation candidates:
+
+| Category | Criteria | Action |
+|----------|----------|--------|
+| **Graduate to rule** | `type == "accepted"`, `confidence >= 0.9`, `occurrences >= 5`, describes a structural code pattern | Generate ast-grep YAML rule |
+| **Graduate to suppress** | `type == "rejected"`, `suppressed == true`, `occurrences >= 3` | Add to suppress-patterns.yaml |
+| **Prune** | `type == "rejected"`, `confidence == 0.0`, `occurrences >= 5` | Remove from learnings.json |
+| **Keep** | All others | No action |
+
+### 2. Generate ast-grep Rules
+
+For each "graduate to rule" candidate, generate a YAML rule file:
+
+```yaml
+# Auto-generated from learning <id>
+# Source: PR #<pr>, confidence <confidence>, occurrences <occurrences>
+# Pattern: <learning.pattern>
+id: learning-<short-id>
+language: java
+rule:
+  # Extract the structural pattern from the learning description
+  # This requires LLM interpretation of the natural-language pattern
+  <ast-grep rule body>
+message: "<learning.action>"
+severity: warning
+note: "Auto-generated from review learning. Original pattern: <learning.pattern>"
+```
+
+**Important**: Not all learnings can be expressed as ast-grep rules. Only
+learnings that describe **structural code patterns** (e.g. "empty catch blocks
+in camel-core should log at DEBUG") can be converted. Process/convention
+learnings (e.g. "PRs touching SPI must update the compatibility matrix") should
+be proposed as skill patches instead.
+
+### 3. Generate Suppress Patterns
+
+For each "graduate to suppress" candidate, add to `suppress-patterns.yaml`:
+
+```yaml
+# Auto-generated suppressions from review learnings
+suppressions:
+  - id: suppress-<short-id>
+    rule: <finding_rule that was suppressed>
+    file_pattern: <file_pattern from learning>
+    reason: "<learning.pattern> — dismissed <occurrences>x, confidence <confidence>"
+```
+
+The reviewer prompt should load `suppress-patterns.yaml` and skip findings
+that match a suppression entry.
+
+### 4. Propose Changes
+
+Consolidation outputs should be proposed as changes, not applied directly:
+
+**For ast-grep rules (go to oss-helper):**
+
+```bash
+# Create a branch on the oss-helper repo
+cd ~/.oss-helper  # or wherever oss-helper is cloned
+git checkout -b learnings/consolidate-$(date +%Y%m%d)
+
+# Copy generated rule files
+cp /tmp/generated-rules/*.yml rules/java/quality/
+
+# Commit and push
+git add rules/
+git commit -m "feat(rules): auto-generated rules from review learnings
+
+Generated from $PROJECT learnings consolidation.
+Rules: <list of new rule IDs>
+Source learnings: <list of learning IDs>"
+git push origin learnings/consolidate-$(date +%Y%m%d)
+
+# Open PR
+gh pr create --title "feat(rules): auto-generated rules from review learnings" \
+  --body "These rules were automatically generated from high-confidence review
+learnings on $PROJECT. Each rule has been validated through at least 5 reviews
+with >= 90% confidence.
+
+## New Rules
+<table of new rules with pattern, confidence, occurrences>"
+```
+
+**For skill patches (go to oss-helper):**
+
+Propose a patch to the relevant skill file. Include the learning source
+and confidence data in the commit message.
+
+**For suppress patterns (stay in oss-helper):**
+
+Add to the state branch alongside other state files.
+
+### 5. Update Learnings
+
+After consolidation:
+
+1. For graduated learnings: set a `graduated_to` field with the rule ID or
+   skill patch reference. Keep the learning in the file for audit trail.
+2. For pruned learnings: remove from `learnings.json`.
+3. Push updated `learnings.json` to the state branch.
+
+### 6. Report
+
+```
+## Learnings Consolidation Complete
+
+- Learnings analyzed: <N>
+- Graduated to ast-grep rules: <R> (proposed as PR to oss-helper)
+- Added to suppress patterns: <S>
+- Pruned (zero confidence): <P>
+- Remaining active learnings: <K>
+```
+
+## Constraints
+
+- Never auto-merge generated rules — always propose as PR for human review
+- Include learning provenance (PR numbers, confidence, occurrences) in all generated artifacts
+- Only generate ast-grep rules from structural code patterns, not process/convention learnings
+- Suppress patterns are project-scoped — never leak between projects
+- Keep graduated learnings in `learnings.json` with `graduated_to` for audit trail

--- a/skills/oss-review-loop/learnings.md
+++ b/skills/oss-review-loop/learnings.md
@@ -1,0 +1,168 @@
+# Review Learnings System
+
+Persistent learnings from PR review feedback. The learnings file accumulates
+patterns that were confirmed (accepted) or dismissed (rejected) by humans,
+allowing the review loop to improve over time.
+
+## Data Model
+
+Learnings are stored in `learnings.json` on the state branch alongside STATE.md.
+See `learnings-schema.json` for the full JSON Schema.
+
+### Learning Types
+
+| Type | Created When | Initial Confidence | Decay |
+|------|-------------|-------------------|-------|
+| `accepted` | Reviewer flagged X → human agreed (applied suggestion, resolved comment) | 0.5 | Normal |
+| `rejected` | Reviewer flagged X → human dismissed (dismissed review, merged without resolving) | 0.5 | Normal |
+| `instruction` | Explicit human directive via PR comment or config | 1.0 | Never |
+
+### Confidence Rules
+
+Confidence tracks how reliable a learning is across multiple observations:
+
+- **Initial score**: 0.5 for organic learnings, 1.0 for instructions
+- **On acceptance**: `confidence = min(1.0, confidence + 0.15)`
+- **On rejection**: `confidence = max(0.0, confidence - 0.25)` (faster decay — false positives are costly)
+- **Auto-suppress**: When `confidence < 0.1` AND `occurrences >= 3`, set `suppressed = true`
+- **Instructions**: Never decay, never auto-suppress
+
+### File Pattern Scoping
+
+Each learning has an optional `file_pattern` glob (e.g. `src/main/**/*.java`,
+`**/pom.xml`). When loading learnings for a PR, filter to learnings whose
+`file_pattern` matches at least one file in the PR diff. Learnings without a
+`file_pattern` apply to all files.
+
+## Loading Learnings
+
+During the review loop (step 1, Read State), load `learnings.json` from the
+state branch:
+
+```bash
+# Read learnings from state branch via API
+LEARNINGS=$(gh api repos/$FORK_REPO/contents/learnings.json?ref=$STATE_BRANCH \
+  --jq '.content' 2>/dev/null | base64 -d)
+```
+
+If the file doesn't exist, start with an empty learnings set.
+
+### Filtering for a PR
+
+Before injecting into the reviewer prompt, filter learnings:
+
+1. Remove `suppressed == true` entries
+2. Remove entries where `file_pattern` doesn't match any file in the PR diff
+3. Sort by confidence (highest first)
+4. Limit to top 20 to avoid prompt bloat
+
+## Injecting into Reviews
+
+Split filtered learnings into two categories for the reviewer prompt:
+
+### BOOST (high-confidence accepted patterns)
+
+Learnings with `type == "accepted"` AND `confidence >= 0.5`:
+
+```
+## Review Learnings — BOOST
+These patterns were confirmed as real issues in past reviews on this project.
+Pay extra attention when you see them:
+
+- [confidence: 0.85, seen 6x] Empty catch blocks in camel-core components
+  should always log at DEBUG level (project convention)
+- [confidence: 0.65, seen 3x] New public API methods in SPI packages require
+  @since javadoc tag
+```
+
+### SUPPRESS (low-confidence rejected patterns)
+
+Learnings with `type == "rejected"` AND `confidence < 0.3`:
+
+```
+## Review Learnings — SUPPRESS
+These patterns were previously flagged but dismissed by maintainers.
+Do NOT flag them unless you have strong new evidence:
+
+- [confidence: 0.15, dismissed 4x] Unused imports in test files — project
+  uses star imports intentionally
+- [confidence: 0.10, dismissed 3x] Missing null checks on CamelContext
+  parameters — guaranteed non-null by framework
+```
+
+### Instructions
+
+Learnings with `type == "instruction"` are always included:
+
+```
+## Review Instructions (from project maintainers)
+- Always check for SQL injection in controller files
+- Camel endpoint URIs must use constants, not string concatenation
+```
+
+## Detecting Feedback
+
+After posting reviews (review-loop step 7), scan for feedback on past reviews
+to update learnings. Check reviews posted in the last 7 days:
+
+### Signal: Suggestion Applied
+
+```bash
+# Get commits after our review
+REVIEW_DATE="<date of our review>"
+gh api repos/$UPSTREAM_REPO/pulls/<NUMBER>/commits \
+  --jq "[.[] | select(.commit.committer.date > \"$REVIEW_DATE\")] | length"
+```
+
+If there are commits after our review AND they touch the same file/line we
+commented on → likely **accepted**. Verify by checking if the commit diff
+matches our suggestion.
+
+### Signal: Review Dismissed
+
+```bash
+gh api repos/$UPSTREAM_REPO/pulls/<NUMBER>/reviews \
+  --jq '.[] | select(.body | contains("AI agent")) | select(.state == "DISMISSED")'
+```
+
+If our review was dismissed → **rejected**.
+
+### Signal: PR Merged Without Resolution
+
+```bash
+gh pr view <NUMBER> --repo $UPSTREAM_REPO --json state,mergedAt
+```
+
+If the PR was merged and our review comments were not resolved → likely
+**rejected** (maintainer chose to ignore the finding).
+
+### Signal: Explicit Feedback
+
+If a maintainer replies to our review comment with keywords:
+- "good catch", "fixed", "thanks" → **accepted**
+- "false positive", "intentional", "by design", "not an issue" → **rejected**
+- "always check for...", "rule: ..." → create **instruction**
+
+## Updating Learnings
+
+For each feedback signal detected:
+
+1. **Find existing learning** matching the same `finding_rule` + `file_pattern`
+2. If found:
+   - Update `confidence` using the growth/decay rules
+   - Increment `occurrences`
+   - Update `last_seen`
+   - Check auto-suppress condition
+3. If not found:
+   - Create a new learning entry with a UUID, initial confidence 0.5
+   - Extract `finding_rule` from the review comment (ast-grep rule ID or general pattern)
+   - Extract `file_pattern` from the reviewed file path
+4. Push updated `learnings.json` alongside other state files
+
+## Constraints
+
+- Learnings are **per-project** — each project's state branch has its own `learnings.json`
+- Maximum 100 learnings per project (oldest low-confidence entries pruned first)
+- Instructions are never auto-pruned
+- Suppressed learnings are still stored (for audit) but excluded from prompts
+- Never leak learnings from one project into another project's reviews

--- a/skills/oss-review-loop/pr-review-triage.md
+++ b/skills/oss-review-loop/pr-review-triage.md
@@ -1,0 +1,74 @@
+---
+name: pr-review-triage
+description: >
+  Quick triage per PR: CI status, review comments, merge readiness.
+  Outputs green/red CI, approval counts, blocking comments, and suggested action.
+user-invocable: true
+---
+
+# PR Review Triage
+
+Quick triage of a single PR to determine review priority and readiness.
+
+## Inputs
+
+- PR number
+- **UPSTREAM_REPO** (from init)
+
+## Process
+
+### 1. Fetch PR Status
+
+```bash
+# CI checks
+gh pr checks <NUMBER> --repo $UPSTREAM_REPO
+
+# Review status
+gh pr view <NUMBER> --repo $UPSTREAM_REPO \
+  --json reviewDecision,reviews,labels,mergeable,mergeStateStatus
+
+# Recent activity
+gh api repos/$UPSTREAM_REPO/pulls/<NUMBER>/comments --jq 'length'
+```
+
+### 2. Assess
+
+- **CI status**: green / red / pending
+- **Review state**: approved / changes requested / review required / no reviews
+- **Blocking comments**: count of unresolved review threads
+- **Merge readiness**: all checks green + approved + no blocking comments
+- **Age**: days since creation
+- **Size**: additions + deletions
+
+### 3. Suggest Action
+
+| State | Action |
+|-------|--------|
+| No reviews, CI green | Review (high priority) |
+| No reviews, CI red | Skip until CI green |
+| Changes requested, updated since | Re-review |
+| Already approved by human | Review anyway (verify) |
+| Draft | Skip |
+| Bot PR | Skip |
+| PR idle > 4 days | Suggest human handoff |
+| High-risk labels (security, breaking) | Escalate to human |
+
+## Output
+
+```markdown
+## Triage: PR #<NUMBER>
+
+- **CI:** green | red | pending
+- **Reviews:** <N> approvals, <M> changes requested
+- **Blocking:** <K> unresolved threads
+- **Merge-ready:** yes | no (<reason>)
+- **Priority:** high | medium | low
+- **Action:** review | skip | re-review | wait-for-ci | escalate-human
+```
+
+## Rules
+
+- "Ready to merge" requires all required checks + approvals per project policy.
+- Non-actionable nits: note but do not spawn fix.
+- If PR idle > 4 days: suggest human handoff.
+- High-risk labels (security, breaking): escalate-human always.

--- a/skills/oss-review-loop/review-loop.md
+++ b/skills/oss-review-loop/review-loop.md
@@ -40,49 +40,53 @@ Main loop (orchestrator)
 
 ## Execution Steps
 
-### 0. Pre-flight — Wait for Activity
+### 0. MANDATORY — Block Until Activity Detected
 
-Run the blocking precondition script. It polls the GitHub Events API using
-ETag-based conditional requests (free on 304 Not Modified) and only returns
-when actionable PRs are detected — or when the timeout expires.
+> **🛑 STOP. Do NOT skip this step. Do NOT proceed to step 1.**
+>
+> You MUST run the blocking precondition script FIRST, BEFORE doing anything
+> else. This script polls GitHub using zero-cost ETag requests and BLOCKS
+> until there is actual PR activity. Without it, you burn tokens checking
+> for work that doesn't exist.
+>
+> **If you skip this step and go straight to `gh pr list`, you are doing it
+> wrong.** The whole point of this loop is to sleep cheaply and only wake up
+> when there's work.
 
-This means **zero LLM tokens are consumed while waiting**. The script blocks
-the session, not the model.
-
-**With `/goal` (recommended for Claude Code — immediate reactivity):**
+Run these commands NOW, before reading any further:
 
 ```bash
+# 1. Pull latest state from the fork
 ~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
+
+# 2. BLOCK here until GitHub activity is detected
+#    This command will NOT return for minutes or hours. That is correct.
+#    Do NOT interrupt it. Do NOT set a short timeout. Let it block.
 ~/.claude/scripts/wait-for-pr-work.sh state.json
 ```
 
-No timeout — the script blocks indefinitely until PRs are detected.
-After each review cycle, this step runs again and blocks until the next
-activity. The `/goal` keeps the session alive across cycles.
+**This command blocks.** It sits in a `while true` loop, polling the GitHub
+Events API with ETag conditional requests (304 = free, no rate limit hit).
+It will return ONLY when:
+- New PR activity is detected (exit 0 → proceed to step 1)
+- The kill switch is set in state.json (exit 1 → stop, do nothing)
 
-**With `/loop` (recommended for ForgeBot — persistence across restarts):**
+**Expected behavior:** After you run this command, nothing happens for a long
+time. That is correct. The script is sleeping and polling. You are saving
+tokens by not doing anything until there's actual work.
 
+**With ForgeBot `/loop`:** Use `--timeout` matching the loop interval:
 ```bash
-~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
 ~/.claude/scripts/wait-for-pr-work.sh --timeout 900 state.json
 ```
+Exit 1 on timeout = skip this tick, report nothing, exit immediately.
 
-Timeout matches the `/loop` interval. Exit 1 on timeout = skip this tick.
+**Do NOT proceed past this point until `wait-for-pr-work.sh` returns exit 0.**
 
-> **`/goal` vs `/loop` — which to use?**
->
-> | | `/goal` | `/loop 15m` | ForgeBot `/loop` |
-> |---|---|---|---|
-> | **Reactivity** | Immediate | Up to 15m delay | Up to 15m delay |
-> | **Persistence** | ❌ Dies with session | ❌ Dies with session | ✅ Survives restart |
-> | **Best for** | Claude Code users | — | ForgeBot deployments |
->
-> With blocking ETag scripts, `/goal` is the natural fit for Claude Code:
-> the script *is* the timer. `/loop` adds an unnecessary second layer of
-> waiting. Use `/loop` only with ForgeBot (which persists loops in DB).
-
-If the script exits with code 1 (timeout, no work, or kill switch), **skip
-this iteration entirely** (or wait for `/goal` to re-invoke).
+If it exits with code 1 (timeout, no work, or kill switch):
+- **Output nothing.** Do not say "no PRs found" or "queue empty."
+- **Do not run `gh pr list`.** The script already checked.
+- **Exit immediately.** The loop will fire again later.
 
 If it exits with code 0, proceed:
 

--- a/skills/oss-review-loop/review-loop.md
+++ b/skills/oss-review-loop/review-loop.md
@@ -1,0 +1,358 @@
+---
+name: review-loop
+description: >
+  PR review loop. Lists open PRs, filters already-reviewed
+  ones, triages new/updated PRs, and reviews them using sub-agents with
+  a maker/checker pattern. Tracks state in STATE.md.
+user-invocable: true
+---
+
+# PR Review Loop
+
+Automated loop that discovers, triages, and reviews open PRs.
+Uses sub-agents for parallel review and verification, and the oss-helper
+`review-pr.md` guideline for the actual review logic.
+
+## Architecture
+
+```
+Main loop (orchestrator)
+  +-- Step 1-4: Triage (inline -- fast, low cost)
+  |
+  +-- Step 5: Review (sub-agents, parallel)
+  |     +-- Reviewer agent PR #1234  <- gets learnings, runs review-pr.md (incl. SA)
+  |     +-- Reviewer agent PR #5678
+  |     +-- Reviewer agent PR #9012
+  |
+  +-- Step 6: Verify (sub-agents, one per review)
+  |     +-- Verifier agent PR #1234  <- checks reviewer's findings
+  |     +-- Verifier agent PR #5678
+  |     +-- Verifier agent PR #9012
+  |
+  +-- Step 7-8: Post & update state (inline)
+```
+
+- **Reviewer agents** do the deep review work (read diff, git history, project rules).
+  Each runs in parallel to avoid serializing expensive diff analysis.
+- **Verifier agents** independently check each reviewer's findings for false positives
+  before anything is posted to GitHub. This is the maker/checker split.
+- **No worktrees needed** -- reviews are read-only (diffs come from `gh pr diff`).
+
+## Execution Steps
+
+### 0. Pre-flight — Wait for Activity
+
+Run the blocking precondition script. It polls the GitHub Events API using
+ETag-based conditional requests (free on 304 Not Modified) and only returns
+when actionable PRs are detected — or when the timeout expires.
+
+This means **zero LLM tokens are consumed while waiting**. The script blocks
+the session, not the model.
+
+**With `/goal` (recommended for Claude Code — immediate reactivity):**
+
+```bash
+~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
+~/.claude/scripts/wait-for-pr-work.sh state.json
+```
+
+No timeout — the script blocks indefinitely until PRs are detected.
+After each review cycle, this step runs again and blocks until the next
+activity. The `/goal` keeps the session alive across cycles.
+
+**With `/loop` (recommended for ForgeBot — persistence across restarts):**
+
+```bash
+~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
+~/.claude/scripts/wait-for-pr-work.sh --timeout 900 state.json
+```
+
+Timeout matches the `/loop` interval. Exit 1 on timeout = skip this tick.
+
+> **`/goal` vs `/loop` — which to use?**
+>
+> | | `/goal` | `/loop 15m` | ForgeBot `/loop` |
+> |---|---|---|---|
+> | **Reactivity** | Immediate | Up to 15m delay | Up to 15m delay |
+> | **Persistence** | ❌ Dies with session | ❌ Dies with session | ✅ Survives restart |
+> | **Best for** | Claude Code users | — | ForgeBot deployments |
+>
+> With blocking ETag scripts, `/goal` is the natural fit for Claude Code:
+> the script *is* the timer. `/loop` adds an unnecessary second layer of
+> waiting. Use `/loop` only with ForgeBot (which persists loops in DB).
+
+If the script exits with code 1 (timeout, no work, or kill switch), **skip
+this iteration entirely** (or wait for `/goal` to re-invoke).
+
+If it exits with code 0, proceed:
+
+1. Run the ForgeBot init steps (read `init.md`) to detect the project and load config.
+2. Read `loop-config.json` -- load constraints, budget, cadence (all in one file).
+3. Check `state.json` `paused` flag -- if true, exit immediately.
+
+From initialization, you now have:
+- **UPSTREAM_REPO**: the upstream org/repo (from `project-info.md`)
+- **FORK_REPO**: the operator's fork org/repo
+- **OPERATOR_NAME**: for attribution
+- **MAX_PRS_PER_RUN**: from `loop-config.json`
+- **STATE_BRANCH**: from `loop-config.json`
+
+### 0.5 Check for Unanswered Replies (Deterministic — No LLM for detection)
+
+Before triaging new PRs, check if anyone replied to our past review comments:
+
+```bash
+python3 ~/.claude/scripts/check-review-replies.py $UPSTREAM_REPO state.json --days 14 \
+  > /tmp/unanswered-replies.json 2>/dev/null
+```
+
+If the script exits with code 0, there are unanswered replies. These take
+priority over new reviews — someone is waiting for our response.
+
+For each unanswered reply (this part needs the LLM):
+- **Questions**: read the thread context and respond with a helpful answer
+- **Disagreements**: re-examine our original finding, concede if wrong, clarify if right
+- **Acknowledgments**: no response needed (but note the positive signal for learnings)
+
+Post replies via the GitHub API:
+
+```bash
+gh api repos/$UPSTREAM_REPO/pulls/<PR>/comments --method POST \
+  -f body="<response>" \
+  -F in_reply_to=<thread_id>
+```
+
+After responding, record the interaction:
+
+```bash
+python3 ~/.claude/scripts/update-state.py state.json reviewed \
+  --pr <NUMBER> --verdict COMMENT --notes "Responded to <author>'s reply"
+```
+
+### 1. Read Current State
+
+State is already pulled in step 0. Read `state.json` (JSON, no parsing needed):
+
+- `reviewed_prs[]` — already reviewed, with timestamps and verdicts
+- `skipped_prs[]` — permanently skipped, with reasons
+- `last_run` — timestamp, counts from the previous run
+- `paused` — kill switch flag
+
+Also load `learnings.json` (already pulled in step 0).
+
+If either file is missing, start with empty defaults.
+
+### 2. Triage PRs (Deterministic — No LLM)
+
+Run the deterministic triage script to get actionable PRs:
+
+```bash
+python3 ~/.claude/scripts/triage-prs.py $UPSTREAM_REPO state.json \
+  --max $MAX_PRS_PER_RUN --format json > /tmp/actionable-prs.json
+```
+
+This script handles all filtering (bots, drafts, already-reviewed, skipped,
+drift detection) and prioritization (review-required, age, recency)
+**without any LLM calls**. The output is a JSON array of actionable PRs
+with number, title, author, priority, and whether it's a re-review.
+
+Select the top N PRs by priority (N = `MAX_PRS_PER_RUN` from loop-budget.md).
+
+### 5. Review PRs (Parallel Sub-agents)
+
+For each selected PR, spawn a **reviewer sub-agent** using the Agent tool.
+Launch all reviewer agents in a single message so they run concurrently.
+
+Each reviewer agent prompt must include:
+
+```
+You are reviewing PR #<NUMBER> on $UPSTREAM_REPO.
+
+## Review Learnings (from past reviews)
+
+<Include filtered learnings from learnings.json here. See learnings.md for
+filtering and formatting rules. Split into BOOST (accepted, confidence >= 0.5),
+SUPPRESS (rejected, confidence < 0.3), and INSTRUCTIONS sections.
+Filter by file_pattern relevance to this PR's changed files.
+Limit to top 20 learnings. Omit this section entirely if no learnings exist.>
+
+IMPORTANT: Before doing anything else, read and follow the oss-helper review-pr
+guideline. This is the canonical review process for this project:
+
+1. Read the oss-helper skill and review guideline:
+   - Read the oss-review skill files (if installed)
+   - Read review-pr.md (the review process)
+
+2. Run the oss-helper initialization:
+   - Detect project from git remote
+   - Load project rules from .oss-ai-helper-rules/
+     (project-info.md, project-standards.md, project-guidelines.md)
+
+3. Follow review-pr.md steps 1-6 exactly:
+   - Parse the PR number
+   - Fetch PR metadata and diff via gh
+   - Investigate git history of modified files (git log, git blame)
+   - Review against the loaded project rules
+   - Evaluate for issues (missing tests, regressions, convention violations, etc.)
+
+4. Return your findings as structured output (do NOT post to GitHub -- the main
+   loop handles that):
+
+   VERDICT: <APPROVE|COMMENT|REQUEST_CHANGES>
+   SUMMARY: <1-2 sentence overall assessment>
+   FINDINGS:
+   - [SEVERITY: high|medium|low] [FILE: path/to/file] [LINE: N] <description>
+   SUGGESTION_BLOCKS:
+   - [FILE: path/to/file] [START_LINE: N] [END_LINE: M]
+     ```suggestion
+     <corrected code>
+     ```
+   GENERAL_COMMENTS:
+   - <comment not tied to a specific line>
+
+Return ONLY the structured output above -- no preamble, no markdown headers.
+```
+
+### 6. Verify Findings (Parallel Sub-agents)
+
+After all reviewer agents complete, spawn a **verifier sub-agent** for each review
+that returned findings (verdict != APPROVE). Launch all verifiers in parallel.
+
+Each verifier agent prompt must include:
+
+```
+You are a verification agent. A reviewer found the following issues in PR #<NUMBER>
+on $UPSTREAM_REPO. Your job is to independently check each finding and determine
+whether it is a TRUE issue or a FALSE POSITIVE.
+
+Be skeptical. Default to marking findings as false positives unless you can
+independently confirm the issue by reading the diff and git history yourself.
+
+PR DIFF (fetch fresh):
+  gh pr diff <NUMBER> --repo $UPSTREAM_REPO
+
+REVIEWER'S FINDINGS:
+<paste the reviewer's structured output here>
+
+For EACH finding, independently verify:
+1. Does the file and line reference exist in the diff?
+2. Is the finding actually a problem, or is it correct code?
+3. Does git history show this was intentional? (git log, git blame)
+4. Does it actually violate the cited rule?
+
+Return your verification as:
+
+VERIFIED_FINDINGS:
+- [FINDING: <original finding summary>] [VERDICT: confirmed|false_positive] [REASON: <why>]
+FINAL_VERDICT: <APPROVE|COMMENT|REQUEST_CHANGES>
+FINAL_SUMMARY: <updated summary after removing false positives>
+
+Return ONLY the structured output above.
+```
+
+### 7. Post Reviews to GitHub
+
+For each PR where the verifier confirmed at least one finding, post the review
+to GitHub. Only include **verified findings** (not false positives).
+
+Build the review using the GitHub API:
+
+```bash
+gh api repos/$UPSTREAM_REPO/pulls/<NUMBER>/reviews --input - <<'EOF'
+{
+  "event": "<COMMENT|REQUEST_CHANGES|APPROVE>",
+  "body": "<FINAL_SUMMARY>\n\n_This review was generated by an AI agent and may contain inaccuracies. Please verify all suggestions before applying._\n\n_Claude Code on behalf of $OPERATOR_NAME_",
+  "comments": [
+    {
+      "path": "<file>",
+      "line": <line>,
+      "side": "RIGHT",
+      "body": "<finding description or suggestion block>"
+    }
+  ]
+}
+EOF
+```
+
+For PRs where all findings were marked as false positives, do NOT post a review.
+
+For PRs where the reviewer returned APPROVE (no findings), always post an
+approving review.
+
+### 7.5 Detect Feedback on Past Reviews (Deterministic — No LLM)
+
+Run the feedback detection script:
+
+```bash
+python3 ~/.claude/scripts/detect-feedback.py $UPSTREAM_REPO state.json learnings.json --days 7
+```
+
+This script deterministically scans past reviews for signals (dismissed,
+merged, new commits) and updates `learnings.json` confidence scores.
+No LLM calls. See `learnings.md` for the data model.
+
+### 8. Update State (Deterministic — No LLM)
+
+After posting reviews, update state using the script:
+
+```bash
+# Record each reviewed PR
+python3 ~/.claude/scripts/update-state.py state.json reviewed \
+  --pr <NUMBER> --title "<title>" --author "<author>" \
+  --verdict <APPROVE|COMMENT|REQUEST_CHANGES> \
+  --notes "<one-line summary>"
+
+# Record skipped PRs
+python3 ~/.claude/scripts/update-state.py state.json skip \
+  --pr <NUMBER> --reason "<reason>"
+
+# Record this run
+python3 ~/.claude/scripts/update-state.py state.json run \
+  --prs-checked <N> --reviews-posted <M> --tokens <T>
+```
+
+### 9. Push State to Fork (Deterministic — No LLM)
+
+```bash
+~/.claude/scripts/push-state.sh $FORK_REPO $STATE_BRANCH \
+  state.json loop-run-log.json learnings.json
+```
+
+This script pushes via the GitHub Contents API — no git checkout needed,
+safe in worktrees. Never force-pushes. If the push fails, logs the error
+and continues.
+
+### 10. Summary
+
+```
+## Loop Complete
+
+- Reviewed: <N> PRs (<M> reviews posted, <K> suppressed by verifier)
+- Skipped: <P> PRs
+- False positive rate: <X>%
+- Remaining in queue: <R> PRs
+- Learnings updated: <L> entries (<A> accepted, <J> rejected, <I> instructions)
+```
+
+## Constraints
+
+You MUST:
+- Read STATE.md before fetching PRs to avoid re-reviewing
+- Spawn reviewer agents in parallel (all in one message)
+- Spawn verifier agents in parallel after reviewers complete
+- Only post verified findings -- never post unverified reviewer output directly
+- Post reviews with the AI-generated disclaimer and operator attribution
+- Update STATE.md after every run
+- Respect the per-run PR limit from loop-budget.md
+- Use project rules from .oss-ai-helper-rules/ for review standards
+- Load and inject learnings into reviewer prompts (see learnings.md)
+- Detect feedback on past reviews and update learnings.json
+- Push learnings.json alongside other state files
+
+You MUST NOT:
+- Merge, close, or label any PR
+- Review draft PRs
+- Post a review without running the verifier first
+- Post reviews where all findings were false positives
+- Skip the git history investigation step in reviewer agents
+- Hardcode any project-specific values (repo names, commands, etc.)

--- a/skills/oss-review-loop/review-loop.md
+++ b/skills/oss-review-loop/review-loop.md
@@ -56,10 +56,17 @@ Main loop (orchestrator)
 Run these commands NOW, before reading any further:
 
 ```bash
-# 1. Pull latest state from the fork
-~/.claude/scripts/pull-state.sh $FORK_REPO $STATE_BRANCH .
+# 1. Detect fork repo and state branch from local config
+#    (loop-config.json exists in the worktree from previous runs or setup)
+FORK_REPO=$(git remote get-url origin 2>/dev/null | sed -E 's#.*github.com[:/]##; s#\.git$##')
+STATE_BRANCH=$(python3 -c "import json; print(json.load(open('loop-config.json'))['state_branch'])" 2>/dev/null || echo "")
 
-# 2. BLOCK here until GitHub activity is detected
+# 2. Pull latest state from the fork (skip if no config yet — first run)
+if [[ -n "$STATE_BRANCH" ]]; then
+  ~/.claude/scripts/pull-state.sh "$FORK_REPO" "$STATE_BRANCH" .
+fi
+
+# 3. BLOCK here until GitHub activity is detected
 #    This command will NOT return for minutes or hours. That is correct.
 #    Do NOT interrupt it. Do NOT set a short timeout. Let it block.
 ~/.claude/scripts/wait-for-pr-work.sh state.json

--- a/skills/oss-review-loop/review-loop.md
+++ b/skills/oss-review-loop/review-loop.md
@@ -80,6 +80,12 @@ fi
 ~/.claude/scripts/wait-for-pr-work.sh state.json
 ```
 
+> **🛑 WHILE THIS SCRIPT IS RUNNING, DO NOTHING ELSE.**
+>
+> Do NOT run any other bash commands in parallel. Do NOT check PR status.
+> Do NOT run `gh pr list`. The script IS the check. Wait for it to exit,
+> then read its output.
+
 **This command blocks.** It sits in a `while true` loop, polling the GitHub
 Events API with ETag conditional requests (304 = free, no rate limit hit).
 It will return ONLY when:

--- a/skills/oss-review-loop/review-loop.md
+++ b/skills/oss-review-loop/review-loop.md
@@ -92,7 +92,7 @@ tokens by not doing anything until there's actual work.
 
 **With ForgeBot `/loop`:** Use `--timeout` matching the loop interval:
 ```bash
-~/.claude/scripts/wait-for-pr-work.sh --timeout 900 state.json
+~/.claude/scripts/wait-for-pr-work.sh --timeout 3600 state.json
 ```
 Exit 1 on timeout = skip this tick, report nothing, exit immediately.
 

--- a/skills/oss-review-loop/review-loop.md
+++ b/skills/oss-review-loop/review-loop.md
@@ -58,7 +58,15 @@ Run these commands NOW, before reading any further:
 ```bash
 # 1. Detect fork repo and state branch from local config
 #    (loop-config.json exists in the worktree from previous runs or setup)
-FORK_REPO=$(git remote get-url origin 2>/dev/null | sed -E 's#.*github.com[:/]##; s#\.git$##')
+#    State is stored on the FORK, not upstream — use the 'fork' remote if it exists
+FORK_REPO=$(git remote get-url fork 2>/dev/null | sed -E 's#.*github.com[:/]##; s#\.git$##')
+if [[ -z "$FORK_REPO" ]]; then
+  # Fallback: try 'gnodet' remote, then 'origin'
+  for remote in gnodet origin; do
+    FORK_REPO=$(git remote get-url "$remote" 2>/dev/null | sed -E 's#.*github.com[:/]##; s#\.git$##')
+    [[ -n "$FORK_REPO" ]] && break
+  done
+fi
 STATE_BRANCH=$(python3 -c "import json; print(json.load(open('loop-config.json'))['state_branch'])" 2>/dev/null || echo "")
 
 # 2. Pull latest state from the fork (skip if no config yet — first run)

--- a/skills/oss-review-loop/review-loop.md
+++ b/skills/oss-review-loop/review-loop.md
@@ -80,11 +80,11 @@ fi
 ~/.claude/scripts/wait-for-pr-work.sh state.json
 ```
 
-> **🛑 WHILE THIS SCRIPT IS RUNNING, DO NOTHING ELSE.**
+> **🛑 Block waiting for this script to finish. Do NOT run any other command.**
 >
-> Do NOT run any other bash commands in parallel. Do NOT check PR status.
-> Do NOT run `gh pr list`. The script IS the check. Wait for it to exit,
-> then read its output.
+> This script will run for minutes or hours. That is expected.
+> Do NOT run any bash command while it is running — not `gh`, not `cat`,
+> not `date`, nothing. Just wait. When it exits, read the output and act.
 
 **This command blocks.** It sits in a `while true` loop, polling the GitHub
 Events API with ETag conditional requests (304 = free, no rate limit hit).


### PR DESCRIPTION
## Summary

Migrates all loop and automation skills from the separate `forgebot-skills` repo (Gitea) into oss-helper. These skills are generic Claude Code skills — they work without ForgeBot.

### New skill groups

| Skill | Description |
|---|---|
| **oss-loop-core** | Circuit breaker, budget, constraints, init, self-update |
| **oss-ci-sweeper** | CI monitoring, failure classification, fix proposals |
| **oss-review-loop** | Automated PR review with maker/checker pattern + learnings |
| **oss-babysit** | PR lifecycle: CI fix → undraft → review addressing → merge |
| **oss-issue-loop** | Issue triage → dispatch fix+babysit tasks |

### New scripts (13 files)

- `wait-for-*.sh` — blocking ETag-based polling (zero-cost idle, zero tokens)
- `triage-prs.py`, `triage-issues.py` — deterministic filtering/prioritization
- `push/pull-state.sh` — state branch management via GitHub API
- `update-state.py` — JSON state CRUD
- `detect-feedback.py`, `check-review-replies.py` — learnings feedback loop
- `init-state-branch.sh` — create state branch with initial JSON files

### Changes to existing files

- `install.sh` — add new SKILL_DIRS + script installation for Claude
- `skills/_shared/init.md` — add auto-update section (git pull on every init)
- `skills/oss-ci/SKILL.md` — add `minimal-fix.md` to capabilities

### Usage

```bash
# Continuous PR review
/goal Monitor and review PRs on this project

# CI sweeper
/goal Monitor CI and fix failures on this project

# Babysit a specific PR
/goal Follow /babysit-pr to babysit PR #1234 until it is merged

# Issue triage + fix + babysit
/goal Monitor and fix issues on this project
```

All `forgebot-*` references renamed to `oss-*`. The `forgebot-skills` repo becomes a thin wrapper pointing to oss-helper (or deprecated).

_Claude Code on behalf of Guillaume Nodet_